### PR TITLE
Update Lean versioning to diff files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,22 +3,46 @@ name: Run Tests
 on: [push, pull_request]
 
 jobs:
-  test:
+  gather-diffs:
     runs-on: ubuntu-latest
-
+    outputs:
+      diff-files: ${{ steps.get-diffs.outputs.diff-files }}
     steps:
-    - name: Checkout code
-      uses: actions/checkout@v2
+      - name: Checkout code
+        uses: actions/checkout@v2
 
-    - name: install elan
-      run: |
-        set -o pipefail
-        curl -sSfL https://github.com/leanprover/elan/releases/download/v3.0.0/elan-x86_64-unknown-linux-gnu.tar.gz | tar xz
-        ./elan-init -y --default-toolchain none
-        echo "$HOME/.elan/bin" >> $GITHUB_PATH
+      - name: Get list of diff files
+        id: get-diffs
+        shell: bash
+        run: |
+          diff_files=$(find versions -name '*.diff' -printf '%P\n' | jq -R -s -c 'split("\n")[:-1]')
+          echo "diff-files=$diff_files" >> $GITHUB_OUTPUT
 
-    - name: build
-      run: lake build
+  test:
+    needs: gather-diffs
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        diff-file: ${{ fromJson(needs.gather-diffs.outputs.diff-files) }}
+    name: Test with ${{ matrix.diff-file }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0 # Ensure full history for git commands
 
-    - name: Run tests
-      run: ./test.sh
+      - name: Apply diff
+        run: git apply "versions/${{ matrix.diff-file }}"
+
+      - name: Install elan
+        run: |
+          set -o pipefail
+          curl -sSfL https://github.com/leanprover/elan/releases/download/v3.0.0/elan-x86_64-unknown-linux-gnu.tar.gz | tar xz
+          ./elan-init -y --default-toolchain none
+          echo "$HOME/.elan/bin" >> $GITHUB_PATH
+
+      - name: Build
+        run: lake build
+
+      - name: Run tests
+        run: ./test.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,7 @@ jobs:
     needs: gather-diffs
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         diff-file: ${{ fromJson(needs.gather-diffs.outputs.diff-files) }}
     name: Test with ${{ matrix.diff-file }}
@@ -29,10 +30,10 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
         with:
-          fetch-depth: 0 # Ensure full history for git commands
+          fetch-depth: 0
 
       - name: Apply diff
-        run: git apply "versions/${{ matrix.diff-file }}"
+        run: git apply "versions/${{ matrix.diff-file }}" --allow-empty
 
       - name: Install elan
         run: |

--- a/versions/v4.10.0-rc1.diff
+++ b/versions/v4.10.0-rc1.diff
@@ -1,0 +1,387 @@
+diff --git a/REPL/Frontend.lean b/REPL/Frontend.lean
+index 9cc0914..a2bb150 100644
+--- a/REPL/Frontend.lean
++++ b/REPL/Frontend.lean
+@@ -20,7 +20,10 @@ def processCommandsWithInfoTrees
+     (commandState : Command.State) : IO (Command.State × List Message × List InfoTree) := do
+   let commandState := { commandState with infoState.enabled := true }
+   let s ← IO.processCommands inputCtx parserState commandState <&> Frontend.State.commandState
+-  pure (s, s.messages.toList, s.infoState.trees.toList)
++  let msgs := s.messages.toList.drop commandState.messages.toList.length
++  let trees := s.infoState.trees.toList.drop commandState.infoState.trees.size
++
++  pure (s, msgs, trees)
+ 
+ /--
+ Process some text input, with or without an existing command state.
+diff --git a/REPL/JSON.lean b/REPL/JSON.lean
+index d5c5ba2..b63c5ea 100644
+--- a/REPL/JSON.lean
++++ b/REPL/JSON.lean
+@@ -83,7 +83,7 @@ structure Sorry where
+ deriving FromJson
+ 
+ instance : ToJson Sorry where
+-  toJson r := Json.mkObj <| .flatten [
++  toJson r := Json.mkObj <| .join [
+     [("goal", r.goal)],
+     [("proofState", toJson r.proofState)],
+     if r.pos.line ≠ 0 then [("pos", toJson r.pos)] else [],
+@@ -132,7 +132,7 @@ def Json.nonemptyList [ToJson α] (k : String) : List α → List (String × Jso
+   | l  => [⟨k, toJson l⟩]
+ 
+ instance : ToJson CommandResponse where
+-  toJson r := Json.mkObj <| .flatten [
++  toJson r := Json.mkObj <| .join [
+     [("env", r.env)],
+     Json.nonemptyList "messages" r.messages,
+     Json.nonemptyList "sorries" r.sorries,
+@@ -153,7 +153,7 @@ structure ProofStepResponse where
+ deriving ToJson, FromJson
+ 
+ instance : ToJson ProofStepResponse where
+-  toJson r := Json.mkObj <| .flatten [
++  toJson r := Json.mkObj <| .join [
+     [("proofState", r.proofState)],
+     [("goals", toJson r.goals)],
+     Json.nonemptyList "messages" r.messages,
+diff --git a/REPL/Lean/Environment.lean b/REPL/Lean/Environment.lean
+index 0b4be3c..61d4e76 100644
+--- a/REPL/Lean/Environment.lean
++++ b/REPL/Lean/Environment.lean
+@@ -26,6 +26,6 @@ and then replace the new constants.
+ def unpickle (path : FilePath) : IO (Environment × CompactedRegion) := unsafe do
+   let ((imports, map₂), region) ← _root_.unpickle (Array Import × PHashMap Name ConstantInfo) path
+   let env ← importModules imports {} 0
+-  return (← env.replay (Std.HashMap.ofList map₂.toList), region)
++  return (← env.replay (HashMap.ofList map₂.toList), region)
+ 
+ end Lean.Environment
+diff --git a/REPL/Lean/InfoTree.lean b/REPL/Lean/InfoTree.lean
+index 7abf0b8..d3b28c1 100644
+--- a/REPL/Lean/InfoTree.lean
++++ b/REPL/Lean/InfoTree.lean
+@@ -131,9 +131,9 @@ partial def filter (p : Info → Bool) (m : MVarId → Bool := fun _ => false) :
+   | .context ctx tree => tree.filter p m |>.map (.context ctx)
+   | .node info children =>
+     if p info then
+-      [.node info (children.toList.map (filter p m)).flatten.toPArray']
++      [.node info (children.toList.map (filter p m)).join.toPArray']
+     else
+-      (children.toList.map (filter p m)).flatten
++      (children.toList.map (filter p m)).join
+   | .hole mvar => if m mvar then [.hole mvar] else []
+ 
+ /-- Discard all nodes besides `.context` nodes and `TacticInfo` nodes. -/
+@@ -156,7 +156,7 @@ partial def findAllInfo (t : InfoTree) (ctx? : Option ContextInfo) (p : Info →
+   | context ctx t => t.findAllInfo (ctx.mergeIntoOuter? ctx?) p
+   | node i ts  =>
+     let info := if p i then [(i, ctx?)] else []
+-    let rest := ts.toList.flatMap (fun t => t.findAllInfo ctx? p)
++    let rest := ts.toList.bind (fun t => t.findAllInfo ctx? p)
+     info ++ rest
+   | _ => []
+ 
+@@ -214,13 +214,13 @@ def sorries (t : InfoTree) : List (ContextInfo × SorryType × Position × Posit
+ 
+ def tactics (t : InfoTree) : List (ContextInfo × Syntax × List MVarId × Position × Position × Array Name) :=
+     -- HACK: creating a child ngen
+-  t.findTacticNodes.map fun ⟨i, ctx⟩ => 
+-    let range := stxRange ctx.fileMap i.stx 
+-    ( { ctx with mctx := i.mctxBefore, ngen := ctx.ngen.mkChild.1 }, 
+-      i.stx, 
+-      i.goalsBefore, 
+-      range.fst, 
+-      range.snd, 
++  t.findTacticNodes.map fun ⟨i, ctx⟩ =>
++    let range := stxRange ctx.fileMap i.stx
++    ( { ctx with mctx := i.mctxBefore, ngen := ctx.ngen.mkChild.1 },
++      i.stx,
++      i.goalsBefore,
++      range.fst,
++      range.snd,
+       i.getUsedConstantsAsSet.toArray )
+ 
+ 
+diff --git a/REPL/Main.lean b/REPL/Main.lean
+index a4b97c3..8211b8c 100644
+--- a/REPL/Main.lean
++++ b/REPL/Main.lean
+@@ -95,7 +95,7 @@ def recordProofSnapshot (proofState : ProofSnapshot) : M m Nat := do
+   return id
+ 
+ def sorries (trees : List InfoTree) (env? : Option Environment) : M m (List Sorry) :=
+-  trees.flatMap InfoTree.sorries |>.filter (fun t => match t.2.1 with
++  trees.bind InfoTree.sorries |>.filter (fun t => match t.2.1 with
+     | .term _ none => false
+     | _ => true ) |>.mapM
+       fun ⟨ctx, g, pos, endPos⟩ => do
+@@ -117,7 +117,7 @@ def ppTactic (ctx : ContextInfo) (stx : Syntax) : IO Format :=
+     pure "<failed to pretty print>"
+ 
+ def tactics (trees : List InfoTree) : M m (List Tactic) :=
+-  trees.flatMap InfoTree.tactics |>.mapM
++  trees.bind InfoTree.tactics |>.mapM
+     fun ⟨ctx, stx, goals, pos, endPos, ns⟩ => do
+       let proofState := some (← ProofSnapshot.create ctx none none goals)
+       let goals := s!"{(← ctx.ppGoals goals)}".trim
+@@ -218,9 +218,9 @@ def runCommand (s : Command) : M IO (CommandResponse ⊕ Error) := do
+   let env ← recordCommandSnapshot cmdSnapshot
+   let jsonTrees := match s.infotree with
+   | some "full" => trees
+-  | some "tactics" => trees.flatMap InfoTree.retainTacticInfo
+-  | some "original" => trees.flatMap InfoTree.retainTacticInfo |>.flatMap InfoTree.retainOriginal
+-  | some "substantive" => trees.flatMap InfoTree.retainTacticInfo |>.flatMap InfoTree.retainSubstantive
++  | some "tactics" => trees.bind InfoTree.retainTacticInfo
++  | some "original" => trees.bind InfoTree.retainTacticInfo |>.bind InfoTree.retainOriginal
++  | some "substantive" => trees.bind InfoTree.retainTacticInfo |>.bind InfoTree.retainSubstantive
+   | _ => []
+   let infotree ← if jsonTrees.isEmpty then
+     pure none
+diff --git a/REPL/Snapshots.lean b/REPL/Snapshots.lean
+index 1114c24..7462141 100644
+--- a/REPL/Snapshots.lean
++++ b/REPL/Snapshots.lean
+@@ -83,7 +83,7 @@ def unpickle (path : FilePath) : IO (CommandSnapshot × CompactedRegion) := unsa
+   let ((imports, map₂, cmdState, cmdContext), region) ←
+     _root_.unpickle (Array Import × PHashMap Name ConstantInfo × CompactableCommandSnapshot ×
+       Command.Context) path
+-  let env ← (← importModules imports {} 0).replay (Std.HashMap.ofList map₂.toList)
++  let env ← (← importModules imports {} 0).replay (HashMap.ofList map₂.toList)
+   let p' : CommandSnapshot :=
+   { cmdState := { cmdState with env }
+     cmdContext }
+@@ -284,9 +284,9 @@ def unpickle (path : FilePath) (cmd? : Option CommandSnapshot) :
+   let env ← match cmd? with
+   | none =>
+     enableInitializersExecution
+-    (← importModules imports {} 0).replay (Std.HashMap.ofList map₂.toList)
++    (← importModules imports {} 0).replay (HashMap.ofList map₂.toList)
+   | some cmd =>
+-    cmd.cmdState.env.replay (Std.HashMap.ofList map₂.toList)
++    cmd.cmdState.env.replay (HashMap.ofList map₂.toList)
+   let p' : ProofSnapshot :=
+   { coreState := { coreState with env }
+     coreContext
+diff --git a/lean-toolchain b/lean-toolchain
+index 1e70935..d69d1ed 100644
+--- a/lean-toolchain
++++ b/lean-toolchain
+@@ -1 +1 @@
+-leanprover/lean4:v4.14.0
++leanprover/lean4:v4.10.0-rc1
+diff --git a/test/Mathlib/lake-manifest.json b/test/Mathlib/lake-manifest.json
+index f312e5a..ec1b4b3 100644
+--- a/test/Mathlib/lake-manifest.json
++++ b/test/Mathlib/lake-manifest.json
+@@ -1,95 +1,75 @@
+ {"version": "1.1.0",
+  "packagesDir": ".lake/packages",
+  "packages":
+- [{"url": "https://github.com/leanprover-community/mathlib4",
+-   "type": "git",
+-   "subDir": null,
+-   "scope": "",
+-   "rev": "4bbdccd9c5f862bf90ff12f0a9e2c8be032b9a84",
+-   "name": "mathlib",
+-   "manifestFile": "lake-manifest.json",
+-   "inputRev": "v4.14.0",
+-   "inherited": false,
+-   "configFile": "lakefile.lean"},
+-  {"url": "https://github.com/leanprover-community/plausible",
++ [{"url": "https://github.com/leanprover-community/batteries",
+    "type": "git",
+    "subDir": null,
+    "scope": "leanprover-community",
+-   "rev": "42dc02bdbc5d0c2f395718462a76c3d87318f7fa",
+-   "name": "plausible",
++   "rev": "2ead90d24b4fac3a05c9c4294daa39bd8686fb98",
++   "name": "batteries",
+    "manifestFile": "lake-manifest.json",
+    "inputRev": "main",
+    "inherited": true,
+-   "configFile": "lakefile.toml"},
+-  {"url": "https://github.com/leanprover-community/LeanSearchClient",
++   "configFile": "lakefile.lean"},
++  {"url": "https://github.com/leanprover-community/quote4",
+    "type": "git",
+    "subDir": null,
+    "scope": "leanprover-community",
+-   "rev": "d7caecce0d0f003fd5e9cce9a61f1dd6ba83142b",
+-   "name": "LeanSearchClient",
++   "rev": "a7bfa63f5dddbcab2d4e0569c4cac74b2585e2c6",
++   "name": "Qq",
+    "manifestFile": "lake-manifest.json",
+-   "inputRev": "main",
++   "inputRev": "master",
+    "inherited": true,
+-   "configFile": "lakefile.toml"},
+-  {"url": "https://github.com/leanprover-community/import-graph",
++   "configFile": "lakefile.lean"},
++  {"url": "https://github.com/leanprover-community/aesop",
+    "type": "git",
+    "subDir": null,
+    "scope": "leanprover-community",
+-   "rev": "519e509a28864af5bed98033dd33b95cf08e9aa7",
+-   "name": "importGraph",
++   "rev": "a64fe24aa94e21404940e9217363a9a1ed9a33a6",
++   "name": "aesop",
+    "manifestFile": "lake-manifest.json",
+-   "inputRev": "v4.14.0",
++   "inputRev": "master",
+    "inherited": true,
+    "configFile": "lakefile.toml"},
+   {"url": "https://github.com/leanprover-community/ProofWidgets4",
+    "type": "git",
+    "subDir": null,
+    "scope": "leanprover-community",
+-   "rev": "68280daef58803f68368eb2e53046dabcd270c9d",
++   "rev": "d1b33202c3a29a079f292de65ea438648123b635",
+    "name": "proofwidgets",
+    "manifestFile": "lake-manifest.json",
+-   "inputRev": "v0.0.47",
++   "inputRev": "v0.0.39",
+    "inherited": true,
+    "configFile": "lakefile.lean"},
+-  {"url": "https://github.com/leanprover-community/aesop",
+-   "type": "git",
+-   "subDir": null,
+-   "scope": "leanprover-community",
+-   "rev": "5a0ec8588855265ade536f35bcdcf0fb24fd6030",
+-   "name": "aesop",
+-   "manifestFile": "lake-manifest.json",
+-   "inputRev": "v4.14.0",
+-   "inherited": true,
+-   "configFile": "lakefile.toml"},
+-  {"url": "https://github.com/leanprover-community/quote4",
++  {"url": "https://github.com/leanprover/lean4-cli",
+    "type": "git",
+    "subDir": null,
+-   "scope": "leanprover-community",
+-   "rev": "303b23fbcea94ac4f96e590c1cad6618fd4f5f41",
+-   "name": "Qq",
++   "scope": "",
++   "rev": "a11566029bd9ec4f68a65394e8c3ff1af74c1a29",
++   "name": "Cli",
+    "manifestFile": "lake-manifest.json",
+-   "inputRev": "master",
++   "inputRev": "main",
+    "inherited": true,
+    "configFile": "lakefile.lean"},
+-  {"url": "https://github.com/leanprover-community/batteries",
++  {"url": "https://github.com/leanprover-community/import-graph",
+    "type": "git",
+    "subDir": null,
+    "scope": "leanprover-community",
+-   "rev": "8d6c853f11a5172efa0e96b9f2be1a83d861cdd9",
+-   "name": "batteries",
++   "rev": "d366a602cc4a325a6f9db3a3991dfa6d6cf409c5",
++   "name": "importGraph",
+    "manifestFile": "lake-manifest.json",
+-   "inputRev": "v4.14.0",
++   "inputRev": "main",
+    "inherited": true,
+    "configFile": "lakefile.toml"},
+-  {"url": "https://github.com/leanprover/lean4-cli",
++  {"url": "https://github.com/leanprover-community/mathlib4",
+    "type": "git",
+    "subDir": null,
+-   "scope": "leanprover",
+-   "rev": "726b3c9ad13acca724d4651f14afc4804a7b0e4d",
+-   "name": "Cli",
++   "scope": "",
++   "rev": "f5c3f06aa7f6d6c221786d2890c345a00e6341f8",
++   "name": "mathlib",
+    "manifestFile": "lake-manifest.json",
+-   "inputRev": "main",
+-   "inherited": true,
+-   "configFile": "lakefile.toml"}],
++   "inputRev": "master",
++   "inherited": false,
++   "configFile": "lakefile.lean"}],
+  "name": "«repl-mathlib-tests»",
+  "lakeDir": ".lake"}
+diff --git a/test/Mathlib/lakefile.toml b/test/Mathlib/lakefile.toml
+index 6ff9631..af41e27 100644
+--- a/test/Mathlib/lakefile.toml
++++ b/test/Mathlib/lakefile.toml
+@@ -1,11 +1,11 @@
+-name = "«repl-mathlib-tests»"
++name           = "«repl-mathlib-tests»"
+ defaultTargets = ["ReplMathlibTests"]
+ 
+ [[require]]
+ name = "mathlib"
+-git = "https://github.com/leanprover-community/mathlib4"
+-rev = "v4.14.0"
++git  = "https://github.com/leanprover-community/mathlib4"
++rev  = "master"
+ 
+ [[lean_lib]]
+-name = "ReplMathlibTests"
++name  = "ReplMathlibTests"
+ globs = ["test.+"]
+diff --git a/test/Mathlib/lean-toolchain b/test/Mathlib/lean-toolchain
+index 401bc14..d69d1ed 100644
+--- a/test/Mathlib/lean-toolchain
++++ b/test/Mathlib/lean-toolchain
+@@ -1 +1 @@
+-leanprover/lean4:v4.14.0
+\ No newline at end of file
++leanprover/lean4:v4.10.0-rc1
+diff --git a/test/all_tactics.expected.out b/test/all_tactics.expected.out
+index 6ec808c..5374db8 100644
+--- a/test/all_tactics.expected.out
++++ b/test/all_tactics.expected.out
+@@ -9,7 +9,7 @@
+    "tactic": "exact t",
+    "proofState": 1,
+    "pos": {"line": 1, "column": 32},
+-   "goals": "t : Nat\n⊢ Nat",
++   "goals": "t : Nat ⊢ Nat",
+    "endPos": {"line": 1, "column": 39}}],
+  "env": 0}
+ 
+diff --git a/test/calc.expected.out b/test/calc.expected.out
+index 94f6a9f..fde8fee 100644
+--- a/test/calc.expected.out
++++ b/test/calc.expected.out
+@@ -1,35 +1,22 @@
+ {"tactics":
+  [{"usedConstants":
+-   ["Trans.trans",
+-    "sorryAx",
+-    "instOfNatNat",
+-    "instTransEq",
+-    "Nat",
+-    "OfNat.ofNat",
+-    "Bool.false",
+-    "Eq"],
++   ["Trans.trans", "instOfNatNat", "instTransEq", "Nat", "OfNat.ofNat", "Eq"],
+    "tactic": "calc\n  3 = 4 := by sorry\n  4 = 5 := by sorry",
+    "proofState": 2,
+    "pos": {"line": 1, "column": 22},
+    "goals": "⊢ 3 = 5",
+    "endPos": {"line": 3, "column": 19}},
+-  {"usedConstants": [],
+-   "tactic": "\n  3 = 4 := by sorry\n  4 = 5 := by sorry",
+-   "proofState": 3,
+-   "pos": {"line": 2, "column": 2},
+-   "goals": "no goals",
+-   "endPos": {"line": 3, "column": 19}},
+   {"usedConstants":
+    ["sorryAx", "instOfNatNat", "Nat", "OfNat.ofNat", "Bool.false", "Eq"],
+    "tactic": "sorry",
+-   "proofState": 4,
++   "proofState": 3,
+    "pos": {"line": 2, "column": 14},
+    "goals": "⊢ 3 = 4",
+    "endPos": {"line": 2, "column": 19}},
+   {"usedConstants":
+    ["sorryAx", "instOfNatNat", "Nat", "OfNat.ofNat", "Bool.false", "Eq"],
+    "tactic": "sorry",
+-   "proofState": 5,
++   "proofState": 4,
+    "pos": {"line": 3, "column": 14},
+    "goals": "⊢ 4 = 5",
+    "endPos": {"line": 3, "column": 19}}],

--- a/versions/v4.10.0-rc2.diff
+++ b/versions/v4.10.0-rc2.diff
@@ -1,0 +1,380 @@
+diff --git a/REPL/Frontend.lean b/REPL/Frontend.lean
+index 9cc0914..a2bb150 100644
+--- a/REPL/Frontend.lean
++++ b/REPL/Frontend.lean
+@@ -20,7 +20,10 @@ def processCommandsWithInfoTrees
+     (commandState : Command.State) : IO (Command.State × List Message × List InfoTree) := do
+   let commandState := { commandState with infoState.enabled := true }
+   let s ← IO.processCommands inputCtx parserState commandState <&> Frontend.State.commandState
+-  pure (s, s.messages.toList, s.infoState.trees.toList)
++  let msgs := s.messages.toList.drop commandState.messages.toList.length
++  let trees := s.infoState.trees.toList.drop commandState.infoState.trees.size
++
++  pure (s, msgs, trees)
+ 
+ /--
+ Process some text input, with or without an existing command state.
+diff --git a/REPL/JSON.lean b/REPL/JSON.lean
+index d5c5ba2..b63c5ea 100644
+--- a/REPL/JSON.lean
++++ b/REPL/JSON.lean
+@@ -83,7 +83,7 @@ structure Sorry where
+ deriving FromJson
+ 
+ instance : ToJson Sorry where
+-  toJson r := Json.mkObj <| .flatten [
++  toJson r := Json.mkObj <| .join [
+     [("goal", r.goal)],
+     [("proofState", toJson r.proofState)],
+     if r.pos.line ≠ 0 then [("pos", toJson r.pos)] else [],
+@@ -132,7 +132,7 @@ def Json.nonemptyList [ToJson α] (k : String) : List α → List (String × Jso
+   | l  => [⟨k, toJson l⟩]
+ 
+ instance : ToJson CommandResponse where
+-  toJson r := Json.mkObj <| .flatten [
++  toJson r := Json.mkObj <| .join [
+     [("env", r.env)],
+     Json.nonemptyList "messages" r.messages,
+     Json.nonemptyList "sorries" r.sorries,
+@@ -153,7 +153,7 @@ structure ProofStepResponse where
+ deriving ToJson, FromJson
+ 
+ instance : ToJson ProofStepResponse where
+-  toJson r := Json.mkObj <| .flatten [
++  toJson r := Json.mkObj <| .join [
+     [("proofState", r.proofState)],
+     [("goals", toJson r.goals)],
+     Json.nonemptyList "messages" r.messages,
+diff --git a/REPL/Lean/Environment.lean b/REPL/Lean/Environment.lean
+index 0b4be3c..61d4e76 100644
+--- a/REPL/Lean/Environment.lean
++++ b/REPL/Lean/Environment.lean
+@@ -26,6 +26,6 @@ and then replace the new constants.
+ def unpickle (path : FilePath) : IO (Environment × CompactedRegion) := unsafe do
+   let ((imports, map₂), region) ← _root_.unpickle (Array Import × PHashMap Name ConstantInfo) path
+   let env ← importModules imports {} 0
+-  return (← env.replay (Std.HashMap.ofList map₂.toList), region)
++  return (← env.replay (HashMap.ofList map₂.toList), region)
+ 
+ end Lean.Environment
+diff --git a/REPL/Lean/InfoTree.lean b/REPL/Lean/InfoTree.lean
+index 7abf0b8..d3b28c1 100644
+--- a/REPL/Lean/InfoTree.lean
++++ b/REPL/Lean/InfoTree.lean
+@@ -131,9 +131,9 @@ partial def filter (p : Info → Bool) (m : MVarId → Bool := fun _ => false) :
+   | .context ctx tree => tree.filter p m |>.map (.context ctx)
+   | .node info children =>
+     if p info then
+-      [.node info (children.toList.map (filter p m)).flatten.toPArray']
++      [.node info (children.toList.map (filter p m)).join.toPArray']
+     else
+-      (children.toList.map (filter p m)).flatten
++      (children.toList.map (filter p m)).join
+   | .hole mvar => if m mvar then [.hole mvar] else []
+ 
+ /-- Discard all nodes besides `.context` nodes and `TacticInfo` nodes. -/
+@@ -156,7 +156,7 @@ partial def findAllInfo (t : InfoTree) (ctx? : Option ContextInfo) (p : Info →
+   | context ctx t => t.findAllInfo (ctx.mergeIntoOuter? ctx?) p
+   | node i ts  =>
+     let info := if p i then [(i, ctx?)] else []
+-    let rest := ts.toList.flatMap (fun t => t.findAllInfo ctx? p)
++    let rest := ts.toList.bind (fun t => t.findAllInfo ctx? p)
+     info ++ rest
+   | _ => []
+ 
+@@ -214,13 +214,13 @@ def sorries (t : InfoTree) : List (ContextInfo × SorryType × Position × Posit
+ 
+ def tactics (t : InfoTree) : List (ContextInfo × Syntax × List MVarId × Position × Position × Array Name) :=
+     -- HACK: creating a child ngen
+-  t.findTacticNodes.map fun ⟨i, ctx⟩ => 
+-    let range := stxRange ctx.fileMap i.stx 
+-    ( { ctx with mctx := i.mctxBefore, ngen := ctx.ngen.mkChild.1 }, 
+-      i.stx, 
+-      i.goalsBefore, 
+-      range.fst, 
+-      range.snd, 
++  t.findTacticNodes.map fun ⟨i, ctx⟩ =>
++    let range := stxRange ctx.fileMap i.stx
++    ( { ctx with mctx := i.mctxBefore, ngen := ctx.ngen.mkChild.1 },
++      i.stx,
++      i.goalsBefore,
++      range.fst,
++      range.snd,
+       i.getUsedConstantsAsSet.toArray )
+ 
+ 
+diff --git a/REPL/Main.lean b/REPL/Main.lean
+index a4b97c3..8211b8c 100644
+--- a/REPL/Main.lean
++++ b/REPL/Main.lean
+@@ -95,7 +95,7 @@ def recordProofSnapshot (proofState : ProofSnapshot) : M m Nat := do
+   return id
+ 
+ def sorries (trees : List InfoTree) (env? : Option Environment) : M m (List Sorry) :=
+-  trees.flatMap InfoTree.sorries |>.filter (fun t => match t.2.1 with
++  trees.bind InfoTree.sorries |>.filter (fun t => match t.2.1 with
+     | .term _ none => false
+     | _ => true ) |>.mapM
+       fun ⟨ctx, g, pos, endPos⟩ => do
+@@ -117,7 +117,7 @@ def ppTactic (ctx : ContextInfo) (stx : Syntax) : IO Format :=
+     pure "<failed to pretty print>"
+ 
+ def tactics (trees : List InfoTree) : M m (List Tactic) :=
+-  trees.flatMap InfoTree.tactics |>.mapM
++  trees.bind InfoTree.tactics |>.mapM
+     fun ⟨ctx, stx, goals, pos, endPos, ns⟩ => do
+       let proofState := some (← ProofSnapshot.create ctx none none goals)
+       let goals := s!"{(← ctx.ppGoals goals)}".trim
+@@ -218,9 +218,9 @@ def runCommand (s : Command) : M IO (CommandResponse ⊕ Error) := do
+   let env ← recordCommandSnapshot cmdSnapshot
+   let jsonTrees := match s.infotree with
+   | some "full" => trees
+-  | some "tactics" => trees.flatMap InfoTree.retainTacticInfo
+-  | some "original" => trees.flatMap InfoTree.retainTacticInfo |>.flatMap InfoTree.retainOriginal
+-  | some "substantive" => trees.flatMap InfoTree.retainTacticInfo |>.flatMap InfoTree.retainSubstantive
++  | some "tactics" => trees.bind InfoTree.retainTacticInfo
++  | some "original" => trees.bind InfoTree.retainTacticInfo |>.bind InfoTree.retainOriginal
++  | some "substantive" => trees.bind InfoTree.retainTacticInfo |>.bind InfoTree.retainSubstantive
+   | _ => []
+   let infotree ← if jsonTrees.isEmpty then
+     pure none
+diff --git a/REPL/Snapshots.lean b/REPL/Snapshots.lean
+index 1114c24..7462141 100644
+--- a/REPL/Snapshots.lean
++++ b/REPL/Snapshots.lean
+@@ -83,7 +83,7 @@ def unpickle (path : FilePath) : IO (CommandSnapshot × CompactedRegion) := unsa
+   let ((imports, map₂, cmdState, cmdContext), region) ←
+     _root_.unpickle (Array Import × PHashMap Name ConstantInfo × CompactableCommandSnapshot ×
+       Command.Context) path
+-  let env ← (← importModules imports {} 0).replay (Std.HashMap.ofList map₂.toList)
++  let env ← (← importModules imports {} 0).replay (HashMap.ofList map₂.toList)
+   let p' : CommandSnapshot :=
+   { cmdState := { cmdState with env }
+     cmdContext }
+@@ -284,9 +284,9 @@ def unpickle (path : FilePath) (cmd? : Option CommandSnapshot) :
+   let env ← match cmd? with
+   | none =>
+     enableInitializersExecution
+-    (← importModules imports {} 0).replay (Std.HashMap.ofList map₂.toList)
++    (← importModules imports {} 0).replay (HashMap.ofList map₂.toList)
+   | some cmd =>
+-    cmd.cmdState.env.replay (Std.HashMap.ofList map₂.toList)
++    cmd.cmdState.env.replay (HashMap.ofList map₂.toList)
+   let p' : ProofSnapshot :=
+   { coreState := { coreState with env }
+     coreContext
+diff --git a/lean-toolchain b/lean-toolchain
+index 1e70935..6a4259f 100644
+--- a/lean-toolchain
++++ b/lean-toolchain
+@@ -1 +1 @@
+-leanprover/lean4:v4.14.0
++leanprover/lean4:v4.10.0-rc2
+diff --git a/test/Mathlib/lake-manifest.json b/test/Mathlib/lake-manifest.json
+index f312e5a..b80ea88 100644
+--- a/test/Mathlib/lake-manifest.json
++++ b/test/Mathlib/lake-manifest.json
+@@ -1,95 +1,75 @@
+ {"version": "1.1.0",
+  "packagesDir": ".lake/packages",
+  "packages":
+- [{"url": "https://github.com/leanprover-community/mathlib4",
+-   "type": "git",
+-   "subDir": null,
+-   "scope": "",
+-   "rev": "4bbdccd9c5f862bf90ff12f0a9e2c8be032b9a84",
+-   "name": "mathlib",
+-   "manifestFile": "lake-manifest.json",
+-   "inputRev": "v4.14.0",
+-   "inherited": false,
+-   "configFile": "lakefile.lean"},
+-  {"url": "https://github.com/leanprover-community/plausible",
++ [{"url": "https://github.com/leanprover-community/batteries",
+    "type": "git",
+    "subDir": null,
+    "scope": "leanprover-community",
+-   "rev": "42dc02bdbc5d0c2f395718462a76c3d87318f7fa",
+-   "name": "plausible",
++   "rev": "c0efc1fd2a0bec51bd55c5b17348af13d7419239",
++   "name": "batteries",
+    "manifestFile": "lake-manifest.json",
+    "inputRev": "main",
+    "inherited": true,
+-   "configFile": "lakefile.toml"},
+-  {"url": "https://github.com/leanprover-community/LeanSearchClient",
++   "configFile": "lakefile.lean"},
++  {"url": "https://github.com/leanprover-community/quote4",
+    "type": "git",
+    "subDir": null,
+    "scope": "leanprover-community",
+-   "rev": "d7caecce0d0f003fd5e9cce9a61f1dd6ba83142b",
+-   "name": "LeanSearchClient",
++   "rev": "a7bfa63f5dddbcab2d4e0569c4cac74b2585e2c6",
++   "name": "Qq",
+    "manifestFile": "lake-manifest.json",
+-   "inputRev": "main",
++   "inputRev": "master",
+    "inherited": true,
+-   "configFile": "lakefile.toml"},
+-  {"url": "https://github.com/leanprover-community/import-graph",
++   "configFile": "lakefile.lean"},
++  {"url": "https://github.com/leanprover-community/aesop",
+    "type": "git",
+    "subDir": null,
+    "scope": "leanprover-community",
+-   "rev": "519e509a28864af5bed98033dd33b95cf08e9aa7",
+-   "name": "importGraph",
++   "rev": "deb5bd446a108da8aa8c1a1b62dd50722b961b73",
++   "name": "aesop",
+    "manifestFile": "lake-manifest.json",
+-   "inputRev": "v4.14.0",
++   "inputRev": "master",
+    "inherited": true,
+    "configFile": "lakefile.toml"},
+   {"url": "https://github.com/leanprover-community/ProofWidgets4",
+    "type": "git",
+    "subDir": null,
+    "scope": "leanprover-community",
+-   "rev": "68280daef58803f68368eb2e53046dabcd270c9d",
++   "rev": "d1b33202c3a29a079f292de65ea438648123b635",
+    "name": "proofwidgets",
+    "manifestFile": "lake-manifest.json",
+-   "inputRev": "v0.0.47",
++   "inputRev": "v0.0.39",
+    "inherited": true,
+    "configFile": "lakefile.lean"},
+-  {"url": "https://github.com/leanprover-community/aesop",
+-   "type": "git",
+-   "subDir": null,
+-   "scope": "leanprover-community",
+-   "rev": "5a0ec8588855265ade536f35bcdcf0fb24fd6030",
+-   "name": "aesop",
+-   "manifestFile": "lake-manifest.json",
+-   "inputRev": "v4.14.0",
+-   "inherited": true,
+-   "configFile": "lakefile.toml"},
+-  {"url": "https://github.com/leanprover-community/quote4",
++  {"url": "https://github.com/leanprover/lean4-cli",
+    "type": "git",
+    "subDir": null,
+-   "scope": "leanprover-community",
+-   "rev": "303b23fbcea94ac4f96e590c1cad6618fd4f5f41",
+-   "name": "Qq",
++   "scope": "",
++   "rev": "a11566029bd9ec4f68a65394e8c3ff1af74c1a29",
++   "name": "Cli",
+    "manifestFile": "lake-manifest.json",
+-   "inputRev": "master",
++   "inputRev": "main",
+    "inherited": true,
+    "configFile": "lakefile.lean"},
+-  {"url": "https://github.com/leanprover-community/batteries",
++  {"url": "https://github.com/leanprover-community/import-graph",
+    "type": "git",
+    "subDir": null,
+    "scope": "leanprover-community",
+-   "rev": "8d6c853f11a5172efa0e96b9f2be1a83d861cdd9",
+-   "name": "batteries",
++   "rev": "68b518c9b352fbee16e6d632adcb7a6d0760e2b7",
++   "name": "importGraph",
+    "manifestFile": "lake-manifest.json",
+-   "inputRev": "v4.14.0",
++   "inputRev": "main",
+    "inherited": true,
+    "configFile": "lakefile.toml"},
+-  {"url": "https://github.com/leanprover/lean4-cli",
++  {"url": "https://github.com/leanprover-community/mathlib4",
+    "type": "git",
+    "subDir": null,
+-   "scope": "leanprover",
+-   "rev": "726b3c9ad13acca724d4651f14afc4804a7b0e4d",
+-   "name": "Cli",
++   "scope": "",
++   "rev": "984c68d7773ac133c74543b99b82c33e53baea6b",
++   "name": "mathlib",
+    "manifestFile": "lake-manifest.json",
+-   "inputRev": "main",
+-   "inherited": true,
+-   "configFile": "lakefile.toml"}],
++   "inputRev": "v4.10.0-rc2",
++   "inherited": false,
++   "configFile": "lakefile.lean"}],
+  "name": "«repl-mathlib-tests»",
+  "lakeDir": ".lake"}
+diff --git a/test/Mathlib/lakefile.toml b/test/Mathlib/lakefile.toml
+index 6ff9631..91882bb 100644
+--- a/test/Mathlib/lakefile.toml
++++ b/test/Mathlib/lakefile.toml
+@@ -4,7 +4,7 @@ defaultTargets = ["ReplMathlibTests"]
+ [[require]]
+ name = "mathlib"
+ git = "https://github.com/leanprover-community/mathlib4"
+-rev = "v4.14.0"
++rev = "v4.10.0-rc2"
+ 
+ [[lean_lib]]
+ name = "ReplMathlibTests"
+diff --git a/test/Mathlib/lean-toolchain b/test/Mathlib/lean-toolchain
+index 401bc14..6a4259f 100644
+--- a/test/Mathlib/lean-toolchain
++++ b/test/Mathlib/lean-toolchain
+@@ -1 +1 @@
+-leanprover/lean4:v4.14.0
+\ No newline at end of file
++leanprover/lean4:v4.10.0-rc2
+diff --git a/test/all_tactics.expected.out b/test/all_tactics.expected.out
+index 6ec808c..5374db8 100644
+--- a/test/all_tactics.expected.out
++++ b/test/all_tactics.expected.out
+@@ -9,7 +9,7 @@
+    "tactic": "exact t",
+    "proofState": 1,
+    "pos": {"line": 1, "column": 32},
+-   "goals": "t : Nat\n⊢ Nat",
++   "goals": "t : Nat ⊢ Nat",
+    "endPos": {"line": 1, "column": 39}}],
+  "env": 0}
+ 
+diff --git a/test/calc.expected.out b/test/calc.expected.out
+index 94f6a9f..fde8fee 100644
+--- a/test/calc.expected.out
++++ b/test/calc.expected.out
+@@ -1,35 +1,22 @@
+ {"tactics":
+  [{"usedConstants":
+-   ["Trans.trans",
+-    "sorryAx",
+-    "instOfNatNat",
+-    "instTransEq",
+-    "Nat",
+-    "OfNat.ofNat",
+-    "Bool.false",
+-    "Eq"],
++   ["Trans.trans", "instOfNatNat", "instTransEq", "Nat", "OfNat.ofNat", "Eq"],
+    "tactic": "calc\n  3 = 4 := by sorry\n  4 = 5 := by sorry",
+    "proofState": 2,
+    "pos": {"line": 1, "column": 22},
+    "goals": "⊢ 3 = 5",
+    "endPos": {"line": 3, "column": 19}},
+-  {"usedConstants": [],
+-   "tactic": "\n  3 = 4 := by sorry\n  4 = 5 := by sorry",
+-   "proofState": 3,
+-   "pos": {"line": 2, "column": 2},
+-   "goals": "no goals",
+-   "endPos": {"line": 3, "column": 19}},
+   {"usedConstants":
+    ["sorryAx", "instOfNatNat", "Nat", "OfNat.ofNat", "Bool.false", "Eq"],
+    "tactic": "sorry",
+-   "proofState": 4,
++   "proofState": 3,
+    "pos": {"line": 2, "column": 14},
+    "goals": "⊢ 3 = 4",
+    "endPos": {"line": 2, "column": 19}},
+   {"usedConstants":
+    ["sorryAx", "instOfNatNat", "Nat", "OfNat.ofNat", "Bool.false", "Eq"],
+    "tactic": "sorry",
+-   "proofState": 5,
++   "proofState": 4,
+    "pos": {"line": 3, "column": 14},
+    "goals": "⊢ 4 = 5",
+    "endPos": {"line": 3, "column": 19}}],

--- a/versions/v4.10.0.diff
+++ b/versions/v4.10.0.diff
@@ -1,0 +1,387 @@
+diff --git a/REPL/Frontend.lean b/REPL/Frontend.lean
+index 9cc0914..a2bb150 100644
+--- a/REPL/Frontend.lean
++++ b/REPL/Frontend.lean
+@@ -20,7 +20,10 @@ def processCommandsWithInfoTrees
+     (commandState : Command.State) : IO (Command.State × List Message × List InfoTree) := do
+   let commandState := { commandState with infoState.enabled := true }
+   let s ← IO.processCommands inputCtx parserState commandState <&> Frontend.State.commandState
+-  pure (s, s.messages.toList, s.infoState.trees.toList)
++  let msgs := s.messages.toList.drop commandState.messages.toList.length
++  let trees := s.infoState.trees.toList.drop commandState.infoState.trees.size
++
++  pure (s, msgs, trees)
+ 
+ /--
+ Process some text input, with or without an existing command state.
+diff --git a/REPL/JSON.lean b/REPL/JSON.lean
+index d5c5ba2..b63c5ea 100644
+--- a/REPL/JSON.lean
++++ b/REPL/JSON.lean
+@@ -83,7 +83,7 @@ structure Sorry where
+ deriving FromJson
+ 
+ instance : ToJson Sorry where
+-  toJson r := Json.mkObj <| .flatten [
++  toJson r := Json.mkObj <| .join [
+     [("goal", r.goal)],
+     [("proofState", toJson r.proofState)],
+     if r.pos.line ≠ 0 then [("pos", toJson r.pos)] else [],
+@@ -132,7 +132,7 @@ def Json.nonemptyList [ToJson α] (k : String) : List α → List (String × Jso
+   | l  => [⟨k, toJson l⟩]
+ 
+ instance : ToJson CommandResponse where
+-  toJson r := Json.mkObj <| .flatten [
++  toJson r := Json.mkObj <| .join [
+     [("env", r.env)],
+     Json.nonemptyList "messages" r.messages,
+     Json.nonemptyList "sorries" r.sorries,
+@@ -153,7 +153,7 @@ structure ProofStepResponse where
+ deriving ToJson, FromJson
+ 
+ instance : ToJson ProofStepResponse where
+-  toJson r := Json.mkObj <| .flatten [
++  toJson r := Json.mkObj <| .join [
+     [("proofState", r.proofState)],
+     [("goals", toJson r.goals)],
+     Json.nonemptyList "messages" r.messages,
+diff --git a/REPL/Lean/Environment.lean b/REPL/Lean/Environment.lean
+index 0b4be3c..61d4e76 100644
+--- a/REPL/Lean/Environment.lean
++++ b/REPL/Lean/Environment.lean
+@@ -26,6 +26,6 @@ and then replace the new constants.
+ def unpickle (path : FilePath) : IO (Environment × CompactedRegion) := unsafe do
+   let ((imports, map₂), region) ← _root_.unpickle (Array Import × PHashMap Name ConstantInfo) path
+   let env ← importModules imports {} 0
+-  return (← env.replay (Std.HashMap.ofList map₂.toList), region)
++  return (← env.replay (HashMap.ofList map₂.toList), region)
+ 
+ end Lean.Environment
+diff --git a/REPL/Lean/InfoTree.lean b/REPL/Lean/InfoTree.lean
+index 7abf0b8..d3b28c1 100644
+--- a/REPL/Lean/InfoTree.lean
++++ b/REPL/Lean/InfoTree.lean
+@@ -131,9 +131,9 @@ partial def filter (p : Info → Bool) (m : MVarId → Bool := fun _ => false) :
+   | .context ctx tree => tree.filter p m |>.map (.context ctx)
+   | .node info children =>
+     if p info then
+-      [.node info (children.toList.map (filter p m)).flatten.toPArray']
++      [.node info (children.toList.map (filter p m)).join.toPArray']
+     else
+-      (children.toList.map (filter p m)).flatten
++      (children.toList.map (filter p m)).join
+   | .hole mvar => if m mvar then [.hole mvar] else []
+ 
+ /-- Discard all nodes besides `.context` nodes and `TacticInfo` nodes. -/
+@@ -156,7 +156,7 @@ partial def findAllInfo (t : InfoTree) (ctx? : Option ContextInfo) (p : Info →
+   | context ctx t => t.findAllInfo (ctx.mergeIntoOuter? ctx?) p
+   | node i ts  =>
+     let info := if p i then [(i, ctx?)] else []
+-    let rest := ts.toList.flatMap (fun t => t.findAllInfo ctx? p)
++    let rest := ts.toList.bind (fun t => t.findAllInfo ctx? p)
+     info ++ rest
+   | _ => []
+ 
+@@ -214,13 +214,13 @@ def sorries (t : InfoTree) : List (ContextInfo × SorryType × Position × Posit
+ 
+ def tactics (t : InfoTree) : List (ContextInfo × Syntax × List MVarId × Position × Position × Array Name) :=
+     -- HACK: creating a child ngen
+-  t.findTacticNodes.map fun ⟨i, ctx⟩ => 
+-    let range := stxRange ctx.fileMap i.stx 
+-    ( { ctx with mctx := i.mctxBefore, ngen := ctx.ngen.mkChild.1 }, 
+-      i.stx, 
+-      i.goalsBefore, 
+-      range.fst, 
+-      range.snd, 
++  t.findTacticNodes.map fun ⟨i, ctx⟩ =>
++    let range := stxRange ctx.fileMap i.stx
++    ( { ctx with mctx := i.mctxBefore, ngen := ctx.ngen.mkChild.1 },
++      i.stx,
++      i.goalsBefore,
++      range.fst,
++      range.snd,
+       i.getUsedConstantsAsSet.toArray )
+ 
+ 
+diff --git a/REPL/Main.lean b/REPL/Main.lean
+index a4b97c3..8211b8c 100644
+--- a/REPL/Main.lean
++++ b/REPL/Main.lean
+@@ -95,7 +95,7 @@ def recordProofSnapshot (proofState : ProofSnapshot) : M m Nat := do
+   return id
+ 
+ def sorries (trees : List InfoTree) (env? : Option Environment) : M m (List Sorry) :=
+-  trees.flatMap InfoTree.sorries |>.filter (fun t => match t.2.1 with
++  trees.bind InfoTree.sorries |>.filter (fun t => match t.2.1 with
+     | .term _ none => false
+     | _ => true ) |>.mapM
+       fun ⟨ctx, g, pos, endPos⟩ => do
+@@ -117,7 +117,7 @@ def ppTactic (ctx : ContextInfo) (stx : Syntax) : IO Format :=
+     pure "<failed to pretty print>"
+ 
+ def tactics (trees : List InfoTree) : M m (List Tactic) :=
+-  trees.flatMap InfoTree.tactics |>.mapM
++  trees.bind InfoTree.tactics |>.mapM
+     fun ⟨ctx, stx, goals, pos, endPos, ns⟩ => do
+       let proofState := some (← ProofSnapshot.create ctx none none goals)
+       let goals := s!"{(← ctx.ppGoals goals)}".trim
+@@ -218,9 +218,9 @@ def runCommand (s : Command) : M IO (CommandResponse ⊕ Error) := do
+   let env ← recordCommandSnapshot cmdSnapshot
+   let jsonTrees := match s.infotree with
+   | some "full" => trees
+-  | some "tactics" => trees.flatMap InfoTree.retainTacticInfo
+-  | some "original" => trees.flatMap InfoTree.retainTacticInfo |>.flatMap InfoTree.retainOriginal
+-  | some "substantive" => trees.flatMap InfoTree.retainTacticInfo |>.flatMap InfoTree.retainSubstantive
++  | some "tactics" => trees.bind InfoTree.retainTacticInfo
++  | some "original" => trees.bind InfoTree.retainTacticInfo |>.bind InfoTree.retainOriginal
++  | some "substantive" => trees.bind InfoTree.retainTacticInfo |>.bind InfoTree.retainSubstantive
+   | _ => []
+   let infotree ← if jsonTrees.isEmpty then
+     pure none
+diff --git a/REPL/Snapshots.lean b/REPL/Snapshots.lean
+index 1114c24..7462141 100644
+--- a/REPL/Snapshots.lean
++++ b/REPL/Snapshots.lean
+@@ -83,7 +83,7 @@ def unpickle (path : FilePath) : IO (CommandSnapshot × CompactedRegion) := unsa
+   let ((imports, map₂, cmdState, cmdContext), region) ←
+     _root_.unpickle (Array Import × PHashMap Name ConstantInfo × CompactableCommandSnapshot ×
+       Command.Context) path
+-  let env ← (← importModules imports {} 0).replay (Std.HashMap.ofList map₂.toList)
++  let env ← (← importModules imports {} 0).replay (HashMap.ofList map₂.toList)
+   let p' : CommandSnapshot :=
+   { cmdState := { cmdState with env }
+     cmdContext }
+@@ -284,9 +284,9 @@ def unpickle (path : FilePath) (cmd? : Option CommandSnapshot) :
+   let env ← match cmd? with
+   | none =>
+     enableInitializersExecution
+-    (← importModules imports {} 0).replay (Std.HashMap.ofList map₂.toList)
++    (← importModules imports {} 0).replay (HashMap.ofList map₂.toList)
+   | some cmd =>
+-    cmd.cmdState.env.replay (Std.HashMap.ofList map₂.toList)
++    cmd.cmdState.env.replay (HashMap.ofList map₂.toList)
+   let p' : ProofSnapshot :=
+   { coreState := { coreState with env }
+     coreContext
+diff --git a/lean-toolchain b/lean-toolchain
+index 1e70935..7f0ea50 100644
+--- a/lean-toolchain
++++ b/lean-toolchain
+@@ -1 +1 @@
+-leanprover/lean4:v4.14.0
++leanprover/lean4:v4.10.0
+diff --git a/test/Mathlib/lake-manifest.json b/test/Mathlib/lake-manifest.json
+index f312e5a..cebea85 100644
+--- a/test/Mathlib/lake-manifest.json
++++ b/test/Mathlib/lake-manifest.json
+@@ -1,95 +1,75 @@
+ {"version": "1.1.0",
+  "packagesDir": ".lake/packages",
+  "packages":
+- [{"url": "https://github.com/leanprover-community/mathlib4",
+-   "type": "git",
+-   "subDir": null,
+-   "scope": "",
+-   "rev": "4bbdccd9c5f862bf90ff12f0a9e2c8be032b9a84",
+-   "name": "mathlib",
+-   "manifestFile": "lake-manifest.json",
+-   "inputRev": "v4.14.0",
+-   "inherited": false,
+-   "configFile": "lakefile.lean"},
+-  {"url": "https://github.com/leanprover-community/plausible",
++ [{"url": "https://github.com/leanprover-community/batteries",
+    "type": "git",
+    "subDir": null,
+    "scope": "leanprover-community",
+-   "rev": "42dc02bdbc5d0c2f395718462a76c3d87318f7fa",
+-   "name": "plausible",
++   "rev": "0f3e143dffdc3a591662f3401ce1d7a3405227c0",
++   "name": "batteries",
+    "manifestFile": "lake-manifest.json",
+    "inputRev": "main",
+    "inherited": true,
+-   "configFile": "lakefile.toml"},
+-  {"url": "https://github.com/leanprover-community/LeanSearchClient",
++   "configFile": "lakefile.lean"},
++  {"url": "https://github.com/leanprover-community/quote4",
+    "type": "git",
+    "subDir": null,
+    "scope": "leanprover-community",
+-   "rev": "d7caecce0d0f003fd5e9cce9a61f1dd6ba83142b",
+-   "name": "LeanSearchClient",
++   "rev": "01ad33937acd996ee99eb74eefb39845e4e4b9f5",
++   "name": "Qq",
+    "manifestFile": "lake-manifest.json",
+-   "inputRev": "main",
++   "inputRev": "master",
+    "inherited": true,
+-   "configFile": "lakefile.toml"},
+-  {"url": "https://github.com/leanprover-community/import-graph",
++   "configFile": "lakefile.lean"},
++  {"url": "https://github.com/leanprover-community/aesop",
+    "type": "git",
+    "subDir": null,
+    "scope": "leanprover-community",
+-   "rev": "519e509a28864af5bed98033dd33b95cf08e9aa7",
+-   "name": "importGraph",
++   "rev": "209712c78b16c795453b6da7f7adbda4589a8f21",
++   "name": "aesop",
+    "manifestFile": "lake-manifest.json",
+-   "inputRev": "v4.14.0",
++   "inputRev": "master",
+    "inherited": true,
+    "configFile": "lakefile.toml"},
+   {"url": "https://github.com/leanprover-community/ProofWidgets4",
+    "type": "git",
+    "subDir": null,
+    "scope": "leanprover-community",
+-   "rev": "68280daef58803f68368eb2e53046dabcd270c9d",
++   "rev": "c87908619cccadda23f71262e6898b9893bffa36",
+    "name": "proofwidgets",
+    "manifestFile": "lake-manifest.json",
+-   "inputRev": "v0.0.47",
++   "inputRev": "v0.0.40",
+    "inherited": true,
+    "configFile": "lakefile.lean"},
+-  {"url": "https://github.com/leanprover-community/aesop",
++  {"url": "https://github.com/leanprover/lean4-cli",
+    "type": "git",
+    "subDir": null,
+-   "scope": "leanprover-community",
+-   "rev": "5a0ec8588855265ade536f35bcdcf0fb24fd6030",
+-   "name": "aesop",
++   "scope": "",
++   "rev": "2cf1030dc2ae6b3632c84a09350b675ef3e347d0",
++   "name": "Cli",
+    "manifestFile": "lake-manifest.json",
+-   "inputRev": "v4.14.0",
++   "inputRev": "main",
+    "inherited": true,
+    "configFile": "lakefile.toml"},
+-  {"url": "https://github.com/leanprover-community/quote4",
+-   "type": "git",
+-   "subDir": null,
+-   "scope": "leanprover-community",
+-   "rev": "303b23fbcea94ac4f96e590c1cad6618fd4f5f41",
+-   "name": "Qq",
+-   "manifestFile": "lake-manifest.json",
+-   "inputRev": "master",
+-   "inherited": true,
+-   "configFile": "lakefile.lean"},
+-  {"url": "https://github.com/leanprover-community/batteries",
++  {"url": "https://github.com/leanprover-community/import-graph",
+    "type": "git",
+    "subDir": null,
+    "scope": "leanprover-community",
+-   "rev": "8d6c853f11a5172efa0e96b9f2be1a83d861cdd9",
+-   "name": "batteries",
++   "rev": "543725b3bfed792097fc134adca628406f6145f5",
++   "name": "importGraph",
+    "manifestFile": "lake-manifest.json",
+-   "inputRev": "v4.14.0",
++   "inputRev": "main",
+    "inherited": true,
+    "configFile": "lakefile.toml"},
+-  {"url": "https://github.com/leanprover/lean4-cli",
++  {"url": "https://github.com/leanprover-community/mathlib4",
+    "type": "git",
+    "subDir": null,
+-   "scope": "leanprover",
+-   "rev": "726b3c9ad13acca724d4651f14afc4804a7b0e4d",
+-   "name": "Cli",
++   "scope": "",
++   "rev": "5040d990226fe13a6975eee23261d1dc2b88ddaf",
++   "name": "mathlib",
+    "manifestFile": "lake-manifest.json",
+-   "inputRev": "main",
+-   "inherited": true,
+-   "configFile": "lakefile.toml"}],
++   "inputRev": "master",
++   "inherited": false,
++   "configFile": "lakefile.lean"}],
+  "name": "«repl-mathlib-tests»",
+  "lakeDir": ".lake"}
+diff --git a/test/Mathlib/lakefile.toml b/test/Mathlib/lakefile.toml
+index 6ff9631..af41e27 100644
+--- a/test/Mathlib/lakefile.toml
++++ b/test/Mathlib/lakefile.toml
+@@ -1,11 +1,11 @@
+-name = "«repl-mathlib-tests»"
++name           = "«repl-mathlib-tests»"
+ defaultTargets = ["ReplMathlibTests"]
+ 
+ [[require]]
+ name = "mathlib"
+-git = "https://github.com/leanprover-community/mathlib4"
+-rev = "v4.14.0"
++git  = "https://github.com/leanprover-community/mathlib4"
++rev  = "master"
+ 
+ [[lean_lib]]
+-name = "ReplMathlibTests"
++name  = "ReplMathlibTests"
+ globs = ["test.+"]
+diff --git a/test/Mathlib/lean-toolchain b/test/Mathlib/lean-toolchain
+index 401bc14..7f0ea50 100644
+--- a/test/Mathlib/lean-toolchain
++++ b/test/Mathlib/lean-toolchain
+@@ -1 +1 @@
+-leanprover/lean4:v4.14.0
+\ No newline at end of file
++leanprover/lean4:v4.10.0
+diff --git a/test/all_tactics.expected.out b/test/all_tactics.expected.out
+index 6ec808c..5374db8 100644
+--- a/test/all_tactics.expected.out
++++ b/test/all_tactics.expected.out
+@@ -9,7 +9,7 @@
+    "tactic": "exact t",
+    "proofState": 1,
+    "pos": {"line": 1, "column": 32},
+-   "goals": "t : Nat\n⊢ Nat",
++   "goals": "t : Nat ⊢ Nat",
+    "endPos": {"line": 1, "column": 39}}],
+  "env": 0}
+ 
+diff --git a/test/calc.expected.out b/test/calc.expected.out
+index 94f6a9f..fde8fee 100644
+--- a/test/calc.expected.out
++++ b/test/calc.expected.out
+@@ -1,35 +1,22 @@
+ {"tactics":
+  [{"usedConstants":
+-   ["Trans.trans",
+-    "sorryAx",
+-    "instOfNatNat",
+-    "instTransEq",
+-    "Nat",
+-    "OfNat.ofNat",
+-    "Bool.false",
+-    "Eq"],
++   ["Trans.trans", "instOfNatNat", "instTransEq", "Nat", "OfNat.ofNat", "Eq"],
+    "tactic": "calc\n  3 = 4 := by sorry\n  4 = 5 := by sorry",
+    "proofState": 2,
+    "pos": {"line": 1, "column": 22},
+    "goals": "⊢ 3 = 5",
+    "endPos": {"line": 3, "column": 19}},
+-  {"usedConstants": [],
+-   "tactic": "\n  3 = 4 := by sorry\n  4 = 5 := by sorry",
+-   "proofState": 3,
+-   "pos": {"line": 2, "column": 2},
+-   "goals": "no goals",
+-   "endPos": {"line": 3, "column": 19}},
+   {"usedConstants":
+    ["sorryAx", "instOfNatNat", "Nat", "OfNat.ofNat", "Bool.false", "Eq"],
+    "tactic": "sorry",
+-   "proofState": 4,
++   "proofState": 3,
+    "pos": {"line": 2, "column": 14},
+    "goals": "⊢ 3 = 4",
+    "endPos": {"line": 2, "column": 19}},
+   {"usedConstants":
+    ["sorryAx", "instOfNatNat", "Nat", "OfNat.ofNat", "Bool.false", "Eq"],
+    "tactic": "sorry",
+-   "proofState": 5,
++   "proofState": 4,
+    "pos": {"line": 3, "column": 14},
+    "goals": "⊢ 4 = 5",
+    "endPos": {"line": 3, "column": 19}}],

--- a/versions/v4.11.0-rc1.diff
+++ b/versions/v4.11.0-rc1.diff
@@ -1,0 +1,387 @@
+diff --git a/REPL/Frontend.lean b/REPL/Frontend.lean
+index 9cc0914..a2bb150 100644
+--- a/REPL/Frontend.lean
++++ b/REPL/Frontend.lean
+@@ -20,7 +20,10 @@ def processCommandsWithInfoTrees
+     (commandState : Command.State) : IO (Command.State × List Message × List InfoTree) := do
+   let commandState := { commandState with infoState.enabled := true }
+   let s ← IO.processCommands inputCtx parserState commandState <&> Frontend.State.commandState
+-  pure (s, s.messages.toList, s.infoState.trees.toList)
++  let msgs := s.messages.toList.drop commandState.messages.toList.length
++  let trees := s.infoState.trees.toList.drop commandState.infoState.trees.size
++
++  pure (s, msgs, trees)
+ 
+ /--
+ Process some text input, with or without an existing command state.
+diff --git a/REPL/JSON.lean b/REPL/JSON.lean
+index d5c5ba2..b63c5ea 100644
+--- a/REPL/JSON.lean
++++ b/REPL/JSON.lean
+@@ -83,7 +83,7 @@ structure Sorry where
+ deriving FromJson
+ 
+ instance : ToJson Sorry where
+-  toJson r := Json.mkObj <| .flatten [
++  toJson r := Json.mkObj <| .join [
+     [("goal", r.goal)],
+     [("proofState", toJson r.proofState)],
+     if r.pos.line ≠ 0 then [("pos", toJson r.pos)] else [],
+@@ -132,7 +132,7 @@ def Json.nonemptyList [ToJson α] (k : String) : List α → List (String × Jso
+   | l  => [⟨k, toJson l⟩]
+ 
+ instance : ToJson CommandResponse where
+-  toJson r := Json.mkObj <| .flatten [
++  toJson r := Json.mkObj <| .join [
+     [("env", r.env)],
+     Json.nonemptyList "messages" r.messages,
+     Json.nonemptyList "sorries" r.sorries,
+@@ -153,7 +153,7 @@ structure ProofStepResponse where
+ deriving ToJson, FromJson
+ 
+ instance : ToJson ProofStepResponse where
+-  toJson r := Json.mkObj <| .flatten [
++  toJson r := Json.mkObj <| .join [
+     [("proofState", r.proofState)],
+     [("goals", toJson r.goals)],
+     Json.nonemptyList "messages" r.messages,
+diff --git a/REPL/Lean/Environment.lean b/REPL/Lean/Environment.lean
+index 0b4be3c..61d4e76 100644
+--- a/REPL/Lean/Environment.lean
++++ b/REPL/Lean/Environment.lean
+@@ -26,6 +26,6 @@ and then replace the new constants.
+ def unpickle (path : FilePath) : IO (Environment × CompactedRegion) := unsafe do
+   let ((imports, map₂), region) ← _root_.unpickle (Array Import × PHashMap Name ConstantInfo) path
+   let env ← importModules imports {} 0
+-  return (← env.replay (Std.HashMap.ofList map₂.toList), region)
++  return (← env.replay (HashMap.ofList map₂.toList), region)
+ 
+ end Lean.Environment
+diff --git a/REPL/Lean/InfoTree.lean b/REPL/Lean/InfoTree.lean
+index 7abf0b8..d3b28c1 100644
+--- a/REPL/Lean/InfoTree.lean
++++ b/REPL/Lean/InfoTree.lean
+@@ -131,9 +131,9 @@ partial def filter (p : Info → Bool) (m : MVarId → Bool := fun _ => false) :
+   | .context ctx tree => tree.filter p m |>.map (.context ctx)
+   | .node info children =>
+     if p info then
+-      [.node info (children.toList.map (filter p m)).flatten.toPArray']
++      [.node info (children.toList.map (filter p m)).join.toPArray']
+     else
+-      (children.toList.map (filter p m)).flatten
++      (children.toList.map (filter p m)).join
+   | .hole mvar => if m mvar then [.hole mvar] else []
+ 
+ /-- Discard all nodes besides `.context` nodes and `TacticInfo` nodes. -/
+@@ -156,7 +156,7 @@ partial def findAllInfo (t : InfoTree) (ctx? : Option ContextInfo) (p : Info →
+   | context ctx t => t.findAllInfo (ctx.mergeIntoOuter? ctx?) p
+   | node i ts  =>
+     let info := if p i then [(i, ctx?)] else []
+-    let rest := ts.toList.flatMap (fun t => t.findAllInfo ctx? p)
++    let rest := ts.toList.bind (fun t => t.findAllInfo ctx? p)
+     info ++ rest
+   | _ => []
+ 
+@@ -214,13 +214,13 @@ def sorries (t : InfoTree) : List (ContextInfo × SorryType × Position × Posit
+ 
+ def tactics (t : InfoTree) : List (ContextInfo × Syntax × List MVarId × Position × Position × Array Name) :=
+     -- HACK: creating a child ngen
+-  t.findTacticNodes.map fun ⟨i, ctx⟩ => 
+-    let range := stxRange ctx.fileMap i.stx 
+-    ( { ctx with mctx := i.mctxBefore, ngen := ctx.ngen.mkChild.1 }, 
+-      i.stx, 
+-      i.goalsBefore, 
+-      range.fst, 
+-      range.snd, 
++  t.findTacticNodes.map fun ⟨i, ctx⟩ =>
++    let range := stxRange ctx.fileMap i.stx
++    ( { ctx with mctx := i.mctxBefore, ngen := ctx.ngen.mkChild.1 },
++      i.stx,
++      i.goalsBefore,
++      range.fst,
++      range.snd,
+       i.getUsedConstantsAsSet.toArray )
+ 
+ 
+diff --git a/REPL/Main.lean b/REPL/Main.lean
+index a4b97c3..8211b8c 100644
+--- a/REPL/Main.lean
++++ b/REPL/Main.lean
+@@ -95,7 +95,7 @@ def recordProofSnapshot (proofState : ProofSnapshot) : M m Nat := do
+   return id
+ 
+ def sorries (trees : List InfoTree) (env? : Option Environment) : M m (List Sorry) :=
+-  trees.flatMap InfoTree.sorries |>.filter (fun t => match t.2.1 with
++  trees.bind InfoTree.sorries |>.filter (fun t => match t.2.1 with
+     | .term _ none => false
+     | _ => true ) |>.mapM
+       fun ⟨ctx, g, pos, endPos⟩ => do
+@@ -117,7 +117,7 @@ def ppTactic (ctx : ContextInfo) (stx : Syntax) : IO Format :=
+     pure "<failed to pretty print>"
+ 
+ def tactics (trees : List InfoTree) : M m (List Tactic) :=
+-  trees.flatMap InfoTree.tactics |>.mapM
++  trees.bind InfoTree.tactics |>.mapM
+     fun ⟨ctx, stx, goals, pos, endPos, ns⟩ => do
+       let proofState := some (← ProofSnapshot.create ctx none none goals)
+       let goals := s!"{(← ctx.ppGoals goals)}".trim
+@@ -218,9 +218,9 @@ def runCommand (s : Command) : M IO (CommandResponse ⊕ Error) := do
+   let env ← recordCommandSnapshot cmdSnapshot
+   let jsonTrees := match s.infotree with
+   | some "full" => trees
+-  | some "tactics" => trees.flatMap InfoTree.retainTacticInfo
+-  | some "original" => trees.flatMap InfoTree.retainTacticInfo |>.flatMap InfoTree.retainOriginal
+-  | some "substantive" => trees.flatMap InfoTree.retainTacticInfo |>.flatMap InfoTree.retainSubstantive
++  | some "tactics" => trees.bind InfoTree.retainTacticInfo
++  | some "original" => trees.bind InfoTree.retainTacticInfo |>.bind InfoTree.retainOriginal
++  | some "substantive" => trees.bind InfoTree.retainTacticInfo |>.bind InfoTree.retainSubstantive
+   | _ => []
+   let infotree ← if jsonTrees.isEmpty then
+     pure none
+diff --git a/REPL/Snapshots.lean b/REPL/Snapshots.lean
+index 1114c24..7462141 100644
+--- a/REPL/Snapshots.lean
++++ b/REPL/Snapshots.lean
+@@ -83,7 +83,7 @@ def unpickle (path : FilePath) : IO (CommandSnapshot × CompactedRegion) := unsa
+   let ((imports, map₂, cmdState, cmdContext), region) ←
+     _root_.unpickle (Array Import × PHashMap Name ConstantInfo × CompactableCommandSnapshot ×
+       Command.Context) path
+-  let env ← (← importModules imports {} 0).replay (Std.HashMap.ofList map₂.toList)
++  let env ← (← importModules imports {} 0).replay (HashMap.ofList map₂.toList)
+   let p' : CommandSnapshot :=
+   { cmdState := { cmdState with env }
+     cmdContext }
+@@ -284,9 +284,9 @@ def unpickle (path : FilePath) (cmd? : Option CommandSnapshot) :
+   let env ← match cmd? with
+   | none =>
+     enableInitializersExecution
+-    (← importModules imports {} 0).replay (Std.HashMap.ofList map₂.toList)
++    (← importModules imports {} 0).replay (HashMap.ofList map₂.toList)
+   | some cmd =>
+-    cmd.cmdState.env.replay (Std.HashMap.ofList map₂.toList)
++    cmd.cmdState.env.replay (HashMap.ofList map₂.toList)
+   let p' : ProofSnapshot :=
+   { coreState := { coreState with env }
+     coreContext
+diff --git a/lean-toolchain b/lean-toolchain
+index 1e70935..64981ae 100644
+--- a/lean-toolchain
++++ b/lean-toolchain
+@@ -1 +1 @@
+-leanprover/lean4:v4.14.0
++leanprover/lean4:v4.11.0-rc1
+diff --git a/test/Mathlib/lake-manifest.json b/test/Mathlib/lake-manifest.json
+index f312e5a..88a87d8 100644
+--- a/test/Mathlib/lake-manifest.json
++++ b/test/Mathlib/lake-manifest.json
+@@ -1,95 +1,75 @@
+ {"version": "1.1.0",
+  "packagesDir": ".lake/packages",
+  "packages":
+- [{"url": "https://github.com/leanprover-community/mathlib4",
+-   "type": "git",
+-   "subDir": null,
+-   "scope": "",
+-   "rev": "4bbdccd9c5f862bf90ff12f0a9e2c8be032b9a84",
+-   "name": "mathlib",
+-   "manifestFile": "lake-manifest.json",
+-   "inputRev": "v4.14.0",
+-   "inherited": false,
+-   "configFile": "lakefile.lean"},
+-  {"url": "https://github.com/leanprover-community/plausible",
++ [{"url": "https://github.com/leanprover-community/batteries",
+    "type": "git",
+    "subDir": null,
+    "scope": "leanprover-community",
+-   "rev": "42dc02bdbc5d0c2f395718462a76c3d87318f7fa",
+-   "name": "plausible",
++   "rev": "dc167d260ff7ee9849b436037add06bed15104be",
++   "name": "batteries",
+    "manifestFile": "lake-manifest.json",
+    "inputRev": "main",
+    "inherited": true,
+-   "configFile": "lakefile.toml"},
+-  {"url": "https://github.com/leanprover-community/LeanSearchClient",
++   "configFile": "lakefile.lean"},
++  {"url": "https://github.com/leanprover-community/quote4",
+    "type": "git",
+    "subDir": null,
+    "scope": "leanprover-community",
+-   "rev": "d7caecce0d0f003fd5e9cce9a61f1dd6ba83142b",
+-   "name": "LeanSearchClient",
++   "rev": "01ad33937acd996ee99eb74eefb39845e4e4b9f5",
++   "name": "Qq",
+    "manifestFile": "lake-manifest.json",
+-   "inputRev": "main",
++   "inputRev": "master",
+    "inherited": true,
+-   "configFile": "lakefile.toml"},
+-  {"url": "https://github.com/leanprover-community/import-graph",
++   "configFile": "lakefile.lean"},
++  {"url": "https://github.com/leanprover-community/aesop",
+    "type": "git",
+    "subDir": null,
+    "scope": "leanprover-community",
+-   "rev": "519e509a28864af5bed98033dd33b95cf08e9aa7",
+-   "name": "importGraph",
++   "rev": "ae6ea60e9d8bc2d4b37ff02115854da2e1b710d0",
++   "name": "aesop",
+    "manifestFile": "lake-manifest.json",
+-   "inputRev": "v4.14.0",
++   "inputRev": "master",
+    "inherited": true,
+    "configFile": "lakefile.toml"},
+   {"url": "https://github.com/leanprover-community/ProofWidgets4",
+    "type": "git",
+    "subDir": null,
+    "scope": "leanprover-community",
+-   "rev": "68280daef58803f68368eb2e53046dabcd270c9d",
++   "rev": "a96aee5245720f588876021b6a0aa73efee49c76",
+    "name": "proofwidgets",
+    "manifestFile": "lake-manifest.json",
+-   "inputRev": "v0.0.47",
++   "inputRev": "v0.0.41",
+    "inherited": true,
+    "configFile": "lakefile.lean"},
+-  {"url": "https://github.com/leanprover-community/aesop",
++  {"url": "https://github.com/leanprover/lean4-cli",
+    "type": "git",
+    "subDir": null,
+-   "scope": "leanprover-community",
+-   "rev": "5a0ec8588855265ade536f35bcdcf0fb24fd6030",
+-   "name": "aesop",
++   "scope": "",
++   "rev": "2cf1030dc2ae6b3632c84a09350b675ef3e347d0",
++   "name": "Cli",
+    "manifestFile": "lake-manifest.json",
+-   "inputRev": "v4.14.0",
++   "inputRev": "main",
+    "inherited": true,
+    "configFile": "lakefile.toml"},
+-  {"url": "https://github.com/leanprover-community/quote4",
+-   "type": "git",
+-   "subDir": null,
+-   "scope": "leanprover-community",
+-   "rev": "303b23fbcea94ac4f96e590c1cad6618fd4f5f41",
+-   "name": "Qq",
+-   "manifestFile": "lake-manifest.json",
+-   "inputRev": "master",
+-   "inherited": true,
+-   "configFile": "lakefile.lean"},
+-  {"url": "https://github.com/leanprover-community/batteries",
++  {"url": "https://github.com/leanprover-community/import-graph",
+    "type": "git",
+    "subDir": null,
+    "scope": "leanprover-community",
+-   "rev": "8d6c853f11a5172efa0e96b9f2be1a83d861cdd9",
+-   "name": "batteries",
++   "rev": "68cd8ae0f5b996176d1243d94c56e17de570e3bf",
++   "name": "importGraph",
+    "manifestFile": "lake-manifest.json",
+-   "inputRev": "v4.14.0",
++   "inputRev": "main",
+    "inherited": true,
+    "configFile": "lakefile.toml"},
+-  {"url": "https://github.com/leanprover/lean4-cli",
++  {"url": "https://github.com/leanprover-community/mathlib4",
+    "type": "git",
+    "subDir": null,
+-   "scope": "leanprover",
+-   "rev": "726b3c9ad13acca724d4651f14afc4804a7b0e4d",
+-   "name": "Cli",
++   "scope": "",
++   "rev": "5025874dc5f9f8dd1598190e60ef20dda7b42566",
++   "name": "mathlib",
+    "manifestFile": "lake-manifest.json",
+-   "inputRev": "main",
+-   "inherited": true,
+-   "configFile": "lakefile.toml"}],
++   "inputRev": "master",
++   "inherited": false,
++   "configFile": "lakefile.lean"}],
+  "name": "«repl-mathlib-tests»",
+  "lakeDir": ".lake"}
+diff --git a/test/Mathlib/lakefile.toml b/test/Mathlib/lakefile.toml
+index 6ff9631..af41e27 100644
+--- a/test/Mathlib/lakefile.toml
++++ b/test/Mathlib/lakefile.toml
+@@ -1,11 +1,11 @@
+-name = "«repl-mathlib-tests»"
++name           = "«repl-mathlib-tests»"
+ defaultTargets = ["ReplMathlibTests"]
+ 
+ [[require]]
+ name = "mathlib"
+-git = "https://github.com/leanprover-community/mathlib4"
+-rev = "v4.14.0"
++git  = "https://github.com/leanprover-community/mathlib4"
++rev  = "master"
+ 
+ [[lean_lib]]
+-name = "ReplMathlibTests"
++name  = "ReplMathlibTests"
+ globs = ["test.+"]
+diff --git a/test/Mathlib/lean-toolchain b/test/Mathlib/lean-toolchain
+index 401bc14..64981ae 100644
+--- a/test/Mathlib/lean-toolchain
++++ b/test/Mathlib/lean-toolchain
+@@ -1 +1 @@
+-leanprover/lean4:v4.14.0
+\ No newline at end of file
++leanprover/lean4:v4.11.0-rc1
+diff --git a/test/all_tactics.expected.out b/test/all_tactics.expected.out
+index 6ec808c..5374db8 100644
+--- a/test/all_tactics.expected.out
++++ b/test/all_tactics.expected.out
+@@ -9,7 +9,7 @@
+    "tactic": "exact t",
+    "proofState": 1,
+    "pos": {"line": 1, "column": 32},
+-   "goals": "t : Nat\n⊢ Nat",
++   "goals": "t : Nat ⊢ Nat",
+    "endPos": {"line": 1, "column": 39}}],
+  "env": 0}
+ 
+diff --git a/test/calc.expected.out b/test/calc.expected.out
+index 94f6a9f..fde8fee 100644
+--- a/test/calc.expected.out
++++ b/test/calc.expected.out
+@@ -1,35 +1,22 @@
+ {"tactics":
+  [{"usedConstants":
+-   ["Trans.trans",
+-    "sorryAx",
+-    "instOfNatNat",
+-    "instTransEq",
+-    "Nat",
+-    "OfNat.ofNat",
+-    "Bool.false",
+-    "Eq"],
++   ["Trans.trans", "instOfNatNat", "instTransEq", "Nat", "OfNat.ofNat", "Eq"],
+    "tactic": "calc\n  3 = 4 := by sorry\n  4 = 5 := by sorry",
+    "proofState": 2,
+    "pos": {"line": 1, "column": 22},
+    "goals": "⊢ 3 = 5",
+    "endPos": {"line": 3, "column": 19}},
+-  {"usedConstants": [],
+-   "tactic": "\n  3 = 4 := by sorry\n  4 = 5 := by sorry",
+-   "proofState": 3,
+-   "pos": {"line": 2, "column": 2},
+-   "goals": "no goals",
+-   "endPos": {"line": 3, "column": 19}},
+   {"usedConstants":
+    ["sorryAx", "instOfNatNat", "Nat", "OfNat.ofNat", "Bool.false", "Eq"],
+    "tactic": "sorry",
+-   "proofState": 4,
++   "proofState": 3,
+    "pos": {"line": 2, "column": 14},
+    "goals": "⊢ 3 = 4",
+    "endPos": {"line": 2, "column": 19}},
+   {"usedConstants":
+    ["sorryAx", "instOfNatNat", "Nat", "OfNat.ofNat", "Bool.false", "Eq"],
+    "tactic": "sorry",
+-   "proofState": 5,
++   "proofState": 4,
+    "pos": {"line": 3, "column": 14},
+    "goals": "⊢ 4 = 5",
+    "endPos": {"line": 3, "column": 19}}],

--- a/versions/v4.11.0-rc2.diff
+++ b/versions/v4.11.0-rc2.diff
@@ -1,0 +1,242 @@
+diff --git a/REPL/Frontend.lean b/REPL/Frontend.lean
+index 9cc0914..a2bb150 100644
+--- a/REPL/Frontend.lean
++++ b/REPL/Frontend.lean
+@@ -20,7 +20,10 @@ def processCommandsWithInfoTrees
+     (commandState : Command.State) : IO (Command.State × List Message × List InfoTree) := do
+   let commandState := { commandState with infoState.enabled := true }
+   let s ← IO.processCommands inputCtx parserState commandState <&> Frontend.State.commandState
+-  pure (s, s.messages.toList, s.infoState.trees.toList)
++  let msgs := s.messages.toList.drop commandState.messages.toList.length
++  let trees := s.infoState.trees.toList.drop commandState.infoState.trees.size
++
++  pure (s, msgs, trees)
+ 
+ /--
+ Process some text input, with or without an existing command state.
+diff --git a/REPL/JSON.lean b/REPL/JSON.lean
+index d5c5ba2..b63c5ea 100644
+--- a/REPL/JSON.lean
++++ b/REPL/JSON.lean
+@@ -83,7 +83,7 @@ structure Sorry where
+ deriving FromJson
+ 
+ instance : ToJson Sorry where
+-  toJson r := Json.mkObj <| .flatten [
++  toJson r := Json.mkObj <| .join [
+     [("goal", r.goal)],
+     [("proofState", toJson r.proofState)],
+     if r.pos.line ≠ 0 then [("pos", toJson r.pos)] else [],
+@@ -132,7 +132,7 @@ def Json.nonemptyList [ToJson α] (k : String) : List α → List (String × Jso
+   | l  => [⟨k, toJson l⟩]
+ 
+ instance : ToJson CommandResponse where
+-  toJson r := Json.mkObj <| .flatten [
++  toJson r := Json.mkObj <| .join [
+     [("env", r.env)],
+     Json.nonemptyList "messages" r.messages,
+     Json.nonemptyList "sorries" r.sorries,
+@@ -153,7 +153,7 @@ structure ProofStepResponse where
+ deriving ToJson, FromJson
+ 
+ instance : ToJson ProofStepResponse where
+-  toJson r := Json.mkObj <| .flatten [
++  toJson r := Json.mkObj <| .join [
+     [("proofState", r.proofState)],
+     [("goals", toJson r.goals)],
+     Json.nonemptyList "messages" r.messages,
+diff --git a/REPL/Lean/Environment.lean b/REPL/Lean/Environment.lean
+index 0b4be3c..61d4e76 100644
+--- a/REPL/Lean/Environment.lean
++++ b/REPL/Lean/Environment.lean
+@@ -26,6 +26,6 @@ and then replace the new constants.
+ def unpickle (path : FilePath) : IO (Environment × CompactedRegion) := unsafe do
+   let ((imports, map₂), region) ← _root_.unpickle (Array Import × PHashMap Name ConstantInfo) path
+   let env ← importModules imports {} 0
+-  return (← env.replay (Std.HashMap.ofList map₂.toList), region)
++  return (← env.replay (HashMap.ofList map₂.toList), region)
+ 
+ end Lean.Environment
+diff --git a/REPL/Lean/InfoTree.lean b/REPL/Lean/InfoTree.lean
+index 7abf0b8..d3b28c1 100644
+--- a/REPL/Lean/InfoTree.lean
++++ b/REPL/Lean/InfoTree.lean
+@@ -131,9 +131,9 @@ partial def filter (p : Info → Bool) (m : MVarId → Bool := fun _ => false) :
+   | .context ctx tree => tree.filter p m |>.map (.context ctx)
+   | .node info children =>
+     if p info then
+-      [.node info (children.toList.map (filter p m)).flatten.toPArray']
++      [.node info (children.toList.map (filter p m)).join.toPArray']
+     else
+-      (children.toList.map (filter p m)).flatten
++      (children.toList.map (filter p m)).join
+   | .hole mvar => if m mvar then [.hole mvar] else []
+ 
+ /-- Discard all nodes besides `.context` nodes and `TacticInfo` nodes. -/
+@@ -156,7 +156,7 @@ partial def findAllInfo (t : InfoTree) (ctx? : Option ContextInfo) (p : Info →
+   | context ctx t => t.findAllInfo (ctx.mergeIntoOuter? ctx?) p
+   | node i ts  =>
+     let info := if p i then [(i, ctx?)] else []
+-    let rest := ts.toList.flatMap (fun t => t.findAllInfo ctx? p)
++    let rest := ts.toList.bind (fun t => t.findAllInfo ctx? p)
+     info ++ rest
+   | _ => []
+ 
+@@ -214,13 +214,13 @@ def sorries (t : InfoTree) : List (ContextInfo × SorryType × Position × Posit
+ 
+ def tactics (t : InfoTree) : List (ContextInfo × Syntax × List MVarId × Position × Position × Array Name) :=
+     -- HACK: creating a child ngen
+-  t.findTacticNodes.map fun ⟨i, ctx⟩ => 
+-    let range := stxRange ctx.fileMap i.stx 
+-    ( { ctx with mctx := i.mctxBefore, ngen := ctx.ngen.mkChild.1 }, 
+-      i.stx, 
+-      i.goalsBefore, 
+-      range.fst, 
+-      range.snd, 
++  t.findTacticNodes.map fun ⟨i, ctx⟩ =>
++    let range := stxRange ctx.fileMap i.stx
++    ( { ctx with mctx := i.mctxBefore, ngen := ctx.ngen.mkChild.1 },
++      i.stx,
++      i.goalsBefore,
++      range.fst,
++      range.snd,
+       i.getUsedConstantsAsSet.toArray )
+ 
+ 
+diff --git a/REPL/Main.lean b/REPL/Main.lean
+index a4b97c3..8211b8c 100644
+--- a/REPL/Main.lean
++++ b/REPL/Main.lean
+@@ -95,7 +95,7 @@ def recordProofSnapshot (proofState : ProofSnapshot) : M m Nat := do
+   return id
+ 
+ def sorries (trees : List InfoTree) (env? : Option Environment) : M m (List Sorry) :=
+-  trees.flatMap InfoTree.sorries |>.filter (fun t => match t.2.1 with
++  trees.bind InfoTree.sorries |>.filter (fun t => match t.2.1 with
+     | .term _ none => false
+     | _ => true ) |>.mapM
+       fun ⟨ctx, g, pos, endPos⟩ => do
+@@ -117,7 +117,7 @@ def ppTactic (ctx : ContextInfo) (stx : Syntax) : IO Format :=
+     pure "<failed to pretty print>"
+ 
+ def tactics (trees : List InfoTree) : M m (List Tactic) :=
+-  trees.flatMap InfoTree.tactics |>.mapM
++  trees.bind InfoTree.tactics |>.mapM
+     fun ⟨ctx, stx, goals, pos, endPos, ns⟩ => do
+       let proofState := some (← ProofSnapshot.create ctx none none goals)
+       let goals := s!"{(← ctx.ppGoals goals)}".trim
+@@ -218,9 +218,9 @@ def runCommand (s : Command) : M IO (CommandResponse ⊕ Error) := do
+   let env ← recordCommandSnapshot cmdSnapshot
+   let jsonTrees := match s.infotree with
+   | some "full" => trees
+-  | some "tactics" => trees.flatMap InfoTree.retainTacticInfo
+-  | some "original" => trees.flatMap InfoTree.retainTacticInfo |>.flatMap InfoTree.retainOriginal
+-  | some "substantive" => trees.flatMap InfoTree.retainTacticInfo |>.flatMap InfoTree.retainSubstantive
++  | some "tactics" => trees.bind InfoTree.retainTacticInfo
++  | some "original" => trees.bind InfoTree.retainTacticInfo |>.bind InfoTree.retainOriginal
++  | some "substantive" => trees.bind InfoTree.retainTacticInfo |>.bind InfoTree.retainSubstantive
+   | _ => []
+   let infotree ← if jsonTrees.isEmpty then
+     pure none
+diff --git a/REPL/Snapshots.lean b/REPL/Snapshots.lean
+index 1114c24..7462141 100644
+--- a/REPL/Snapshots.lean
++++ b/REPL/Snapshots.lean
+@@ -83,7 +83,7 @@ def unpickle (path : FilePath) : IO (CommandSnapshot × CompactedRegion) := unsa
+   let ((imports, map₂, cmdState, cmdContext), region) ←
+     _root_.unpickle (Array Import × PHashMap Name ConstantInfo × CompactableCommandSnapshot ×
+       Command.Context) path
+-  let env ← (← importModules imports {} 0).replay (Std.HashMap.ofList map₂.toList)
++  let env ← (← importModules imports {} 0).replay (HashMap.ofList map₂.toList)
+   let p' : CommandSnapshot :=
+   { cmdState := { cmdState with env }
+     cmdContext }
+@@ -284,9 +284,9 @@ def unpickle (path : FilePath) (cmd? : Option CommandSnapshot) :
+   let env ← match cmd? with
+   | none =>
+     enableInitializersExecution
+-    (← importModules imports {} 0).replay (Std.HashMap.ofList map₂.toList)
++    (← importModules imports {} 0).replay (HashMap.ofList map₂.toList)
+   | some cmd =>
+-    cmd.cmdState.env.replay (Std.HashMap.ofList map₂.toList)
++    cmd.cmdState.env.replay (HashMap.ofList map₂.toList)
+   let p' : ProofSnapshot :=
+   { coreState := { coreState with env }
+     coreContext
+diff --git a/lean-toolchain b/lean-toolchain
+index 1e70935..e7a4f40 100644
+--- a/lean-toolchain
++++ b/lean-toolchain
+@@ -1 +1 @@
+-leanprover/lean4:v4.14.0
++leanprover/lean4:v4.11.0-rc2
+diff --git a/test.sh b/test.sh
+index 070ce3d..443c739 100755
+--- a/test.sh
++++ b/test.sh
+@@ -41,6 +41,6 @@ for infile in $IN_DIR/*.in; do
+ 
+ done
+ 
+-# Run the Mathlib tests
+-cp lean-toolchain test/Mathlib/
+-cd test/Mathlib/ && ./test.sh
++# Run the Mathlib tests - skipped as no Mathlib releases exist for v4.11.0-rc3
++# cp lean-toolchain test/Mathlib/
++# cd test/Mathlib/ && ./test.sh
+diff --git a/test/all_tactics.expected.out b/test/all_tactics.expected.out
+index 6ec808c..5374db8 100644
+--- a/test/all_tactics.expected.out
++++ b/test/all_tactics.expected.out
+@@ -9,7 +9,7 @@
+    "tactic": "exact t",
+    "proofState": 1,
+    "pos": {"line": 1, "column": 32},
+-   "goals": "t : Nat\n⊢ Nat",
++   "goals": "t : Nat ⊢ Nat",
+    "endPos": {"line": 1, "column": 39}}],
+  "env": 0}
+ 
+diff --git a/test/calc.expected.out b/test/calc.expected.out
+index 94f6a9f..fde8fee 100644
+--- a/test/calc.expected.out
++++ b/test/calc.expected.out
+@@ -1,35 +1,22 @@
+ {"tactics":
+  [{"usedConstants":
+-   ["Trans.trans",
+-    "sorryAx",
+-    "instOfNatNat",
+-    "instTransEq",
+-    "Nat",
+-    "OfNat.ofNat",
+-    "Bool.false",
+-    "Eq"],
++   ["Trans.trans", "instOfNatNat", "instTransEq", "Nat", "OfNat.ofNat", "Eq"],
+    "tactic": "calc\n  3 = 4 := by sorry\n  4 = 5 := by sorry",
+    "proofState": 2,
+    "pos": {"line": 1, "column": 22},
+    "goals": "⊢ 3 = 5",
+    "endPos": {"line": 3, "column": 19}},
+-  {"usedConstants": [],
+-   "tactic": "\n  3 = 4 := by sorry\n  4 = 5 := by sorry",
+-   "proofState": 3,
+-   "pos": {"line": 2, "column": 2},
+-   "goals": "no goals",
+-   "endPos": {"line": 3, "column": 19}},
+   {"usedConstants":
+    ["sorryAx", "instOfNatNat", "Nat", "OfNat.ofNat", "Bool.false", "Eq"],
+    "tactic": "sorry",
+-   "proofState": 4,
++   "proofState": 3,
+    "pos": {"line": 2, "column": 14},
+    "goals": "⊢ 3 = 4",
+    "endPos": {"line": 2, "column": 19}},
+   {"usedConstants":
+    ["sorryAx", "instOfNatNat", "Nat", "OfNat.ofNat", "Bool.false", "Eq"],
+    "tactic": "sorry",
+-   "proofState": 5,
++   "proofState": 4,
+    "pos": {"line": 3, "column": 14},
+    "goals": "⊢ 4 = 5",
+    "endPos": {"line": 3, "column": 19}}],

--- a/versions/v4.11.0-rc3.diff
+++ b/versions/v4.11.0-rc3.diff
@@ -1,0 +1,242 @@
+diff --git a/REPL/Frontend.lean b/REPL/Frontend.lean
+index 9cc0914..a2bb150 100644
+--- a/REPL/Frontend.lean
++++ b/REPL/Frontend.lean
+@@ -20,7 +20,10 @@ def processCommandsWithInfoTrees
+     (commandState : Command.State) : IO (Command.State × List Message × List InfoTree) := do
+   let commandState := { commandState with infoState.enabled := true }
+   let s ← IO.processCommands inputCtx parserState commandState <&> Frontend.State.commandState
+-  pure (s, s.messages.toList, s.infoState.trees.toList)
++  let msgs := s.messages.toList.drop commandState.messages.toList.length
++  let trees := s.infoState.trees.toList.drop commandState.infoState.trees.size
++
++  pure (s, msgs, trees)
+ 
+ /--
+ Process some text input, with or without an existing command state.
+diff --git a/REPL/JSON.lean b/REPL/JSON.lean
+index d5c5ba2..b63c5ea 100644
+--- a/REPL/JSON.lean
++++ b/REPL/JSON.lean
+@@ -83,7 +83,7 @@ structure Sorry where
+ deriving FromJson
+ 
+ instance : ToJson Sorry where
+-  toJson r := Json.mkObj <| .flatten [
++  toJson r := Json.mkObj <| .join [
+     [("goal", r.goal)],
+     [("proofState", toJson r.proofState)],
+     if r.pos.line ≠ 0 then [("pos", toJson r.pos)] else [],
+@@ -132,7 +132,7 @@ def Json.nonemptyList [ToJson α] (k : String) : List α → List (String × Jso
+   | l  => [⟨k, toJson l⟩]
+ 
+ instance : ToJson CommandResponse where
+-  toJson r := Json.mkObj <| .flatten [
++  toJson r := Json.mkObj <| .join [
+     [("env", r.env)],
+     Json.nonemptyList "messages" r.messages,
+     Json.nonemptyList "sorries" r.sorries,
+@@ -153,7 +153,7 @@ structure ProofStepResponse where
+ deriving ToJson, FromJson
+ 
+ instance : ToJson ProofStepResponse where
+-  toJson r := Json.mkObj <| .flatten [
++  toJson r := Json.mkObj <| .join [
+     [("proofState", r.proofState)],
+     [("goals", toJson r.goals)],
+     Json.nonemptyList "messages" r.messages,
+diff --git a/REPL/Lean/Environment.lean b/REPL/Lean/Environment.lean
+index 0b4be3c..61d4e76 100644
+--- a/REPL/Lean/Environment.lean
++++ b/REPL/Lean/Environment.lean
+@@ -26,6 +26,6 @@ and then replace the new constants.
+ def unpickle (path : FilePath) : IO (Environment × CompactedRegion) := unsafe do
+   let ((imports, map₂), region) ← _root_.unpickle (Array Import × PHashMap Name ConstantInfo) path
+   let env ← importModules imports {} 0
+-  return (← env.replay (Std.HashMap.ofList map₂.toList), region)
++  return (← env.replay (HashMap.ofList map₂.toList), region)
+ 
+ end Lean.Environment
+diff --git a/REPL/Lean/InfoTree.lean b/REPL/Lean/InfoTree.lean
+index 7abf0b8..d3b28c1 100644
+--- a/REPL/Lean/InfoTree.lean
++++ b/REPL/Lean/InfoTree.lean
+@@ -131,9 +131,9 @@ partial def filter (p : Info → Bool) (m : MVarId → Bool := fun _ => false) :
+   | .context ctx tree => tree.filter p m |>.map (.context ctx)
+   | .node info children =>
+     if p info then
+-      [.node info (children.toList.map (filter p m)).flatten.toPArray']
++      [.node info (children.toList.map (filter p m)).join.toPArray']
+     else
+-      (children.toList.map (filter p m)).flatten
++      (children.toList.map (filter p m)).join
+   | .hole mvar => if m mvar then [.hole mvar] else []
+ 
+ /-- Discard all nodes besides `.context` nodes and `TacticInfo` nodes. -/
+@@ -156,7 +156,7 @@ partial def findAllInfo (t : InfoTree) (ctx? : Option ContextInfo) (p : Info →
+   | context ctx t => t.findAllInfo (ctx.mergeIntoOuter? ctx?) p
+   | node i ts  =>
+     let info := if p i then [(i, ctx?)] else []
+-    let rest := ts.toList.flatMap (fun t => t.findAllInfo ctx? p)
++    let rest := ts.toList.bind (fun t => t.findAllInfo ctx? p)
+     info ++ rest
+   | _ => []
+ 
+@@ -214,13 +214,13 @@ def sorries (t : InfoTree) : List (ContextInfo × SorryType × Position × Posit
+ 
+ def tactics (t : InfoTree) : List (ContextInfo × Syntax × List MVarId × Position × Position × Array Name) :=
+     -- HACK: creating a child ngen
+-  t.findTacticNodes.map fun ⟨i, ctx⟩ => 
+-    let range := stxRange ctx.fileMap i.stx 
+-    ( { ctx with mctx := i.mctxBefore, ngen := ctx.ngen.mkChild.1 }, 
+-      i.stx, 
+-      i.goalsBefore, 
+-      range.fst, 
+-      range.snd, 
++  t.findTacticNodes.map fun ⟨i, ctx⟩ =>
++    let range := stxRange ctx.fileMap i.stx
++    ( { ctx with mctx := i.mctxBefore, ngen := ctx.ngen.mkChild.1 },
++      i.stx,
++      i.goalsBefore,
++      range.fst,
++      range.snd,
+       i.getUsedConstantsAsSet.toArray )
+ 
+ 
+diff --git a/REPL/Main.lean b/REPL/Main.lean
+index a4b97c3..8211b8c 100644
+--- a/REPL/Main.lean
++++ b/REPL/Main.lean
+@@ -95,7 +95,7 @@ def recordProofSnapshot (proofState : ProofSnapshot) : M m Nat := do
+   return id
+ 
+ def sorries (trees : List InfoTree) (env? : Option Environment) : M m (List Sorry) :=
+-  trees.flatMap InfoTree.sorries |>.filter (fun t => match t.2.1 with
++  trees.bind InfoTree.sorries |>.filter (fun t => match t.2.1 with
+     | .term _ none => false
+     | _ => true ) |>.mapM
+       fun ⟨ctx, g, pos, endPos⟩ => do
+@@ -117,7 +117,7 @@ def ppTactic (ctx : ContextInfo) (stx : Syntax) : IO Format :=
+     pure "<failed to pretty print>"
+ 
+ def tactics (trees : List InfoTree) : M m (List Tactic) :=
+-  trees.flatMap InfoTree.tactics |>.mapM
++  trees.bind InfoTree.tactics |>.mapM
+     fun ⟨ctx, stx, goals, pos, endPos, ns⟩ => do
+       let proofState := some (← ProofSnapshot.create ctx none none goals)
+       let goals := s!"{(← ctx.ppGoals goals)}".trim
+@@ -218,9 +218,9 @@ def runCommand (s : Command) : M IO (CommandResponse ⊕ Error) := do
+   let env ← recordCommandSnapshot cmdSnapshot
+   let jsonTrees := match s.infotree with
+   | some "full" => trees
+-  | some "tactics" => trees.flatMap InfoTree.retainTacticInfo
+-  | some "original" => trees.flatMap InfoTree.retainTacticInfo |>.flatMap InfoTree.retainOriginal
+-  | some "substantive" => trees.flatMap InfoTree.retainTacticInfo |>.flatMap InfoTree.retainSubstantive
++  | some "tactics" => trees.bind InfoTree.retainTacticInfo
++  | some "original" => trees.bind InfoTree.retainTacticInfo |>.bind InfoTree.retainOriginal
++  | some "substantive" => trees.bind InfoTree.retainTacticInfo |>.bind InfoTree.retainSubstantive
+   | _ => []
+   let infotree ← if jsonTrees.isEmpty then
+     pure none
+diff --git a/REPL/Snapshots.lean b/REPL/Snapshots.lean
+index 1114c24..7462141 100644
+--- a/REPL/Snapshots.lean
++++ b/REPL/Snapshots.lean
+@@ -83,7 +83,7 @@ def unpickle (path : FilePath) : IO (CommandSnapshot × CompactedRegion) := unsa
+   let ((imports, map₂, cmdState, cmdContext), region) ←
+     _root_.unpickle (Array Import × PHashMap Name ConstantInfo × CompactableCommandSnapshot ×
+       Command.Context) path
+-  let env ← (← importModules imports {} 0).replay (Std.HashMap.ofList map₂.toList)
++  let env ← (← importModules imports {} 0).replay (HashMap.ofList map₂.toList)
+   let p' : CommandSnapshot :=
+   { cmdState := { cmdState with env }
+     cmdContext }
+@@ -284,9 +284,9 @@ def unpickle (path : FilePath) (cmd? : Option CommandSnapshot) :
+   let env ← match cmd? with
+   | none =>
+     enableInitializersExecution
+-    (← importModules imports {} 0).replay (Std.HashMap.ofList map₂.toList)
++    (← importModules imports {} 0).replay (HashMap.ofList map₂.toList)
+   | some cmd =>
+-    cmd.cmdState.env.replay (Std.HashMap.ofList map₂.toList)
++    cmd.cmdState.env.replay (HashMap.ofList map₂.toList)
+   let p' : ProofSnapshot :=
+   { coreState := { coreState with env }
+     coreContext
+diff --git a/lean-toolchain b/lean-toolchain
+index 1e70935..28b8e55 100644
+--- a/lean-toolchain
++++ b/lean-toolchain
+@@ -1 +1 @@
+-leanprover/lean4:v4.14.0
++leanprover/lean4:v4.11.0-rc3
+diff --git a/test.sh b/test.sh
+index 070ce3d..443c739 100755
+--- a/test.sh
++++ b/test.sh
+@@ -41,6 +41,6 @@ for infile in $IN_DIR/*.in; do
+ 
+ done
+ 
+-# Run the Mathlib tests
+-cp lean-toolchain test/Mathlib/
+-cd test/Mathlib/ && ./test.sh
++# Run the Mathlib tests - skipped as no Mathlib releases exist for v4.11.0-rc3
++# cp lean-toolchain test/Mathlib/
++# cd test/Mathlib/ && ./test.sh
+diff --git a/test/all_tactics.expected.out b/test/all_tactics.expected.out
+index 6ec808c..5374db8 100644
+--- a/test/all_tactics.expected.out
++++ b/test/all_tactics.expected.out
+@@ -9,7 +9,7 @@
+    "tactic": "exact t",
+    "proofState": 1,
+    "pos": {"line": 1, "column": 32},
+-   "goals": "t : Nat\n⊢ Nat",
++   "goals": "t : Nat ⊢ Nat",
+    "endPos": {"line": 1, "column": 39}}],
+  "env": 0}
+ 
+diff --git a/test/calc.expected.out b/test/calc.expected.out
+index 94f6a9f..fde8fee 100644
+--- a/test/calc.expected.out
++++ b/test/calc.expected.out
+@@ -1,35 +1,22 @@
+ {"tactics":
+  [{"usedConstants":
+-   ["Trans.trans",
+-    "sorryAx",
+-    "instOfNatNat",
+-    "instTransEq",
+-    "Nat",
+-    "OfNat.ofNat",
+-    "Bool.false",
+-    "Eq"],
++   ["Trans.trans", "instOfNatNat", "instTransEq", "Nat", "OfNat.ofNat", "Eq"],
+    "tactic": "calc\n  3 = 4 := by sorry\n  4 = 5 := by sorry",
+    "proofState": 2,
+    "pos": {"line": 1, "column": 22},
+    "goals": "⊢ 3 = 5",
+    "endPos": {"line": 3, "column": 19}},
+-  {"usedConstants": [],
+-   "tactic": "\n  3 = 4 := by sorry\n  4 = 5 := by sorry",
+-   "proofState": 3,
+-   "pos": {"line": 2, "column": 2},
+-   "goals": "no goals",
+-   "endPos": {"line": 3, "column": 19}},
+   {"usedConstants":
+    ["sorryAx", "instOfNatNat", "Nat", "OfNat.ofNat", "Bool.false", "Eq"],
+    "tactic": "sorry",
+-   "proofState": 4,
++   "proofState": 3,
+    "pos": {"line": 2, "column": 14},
+    "goals": "⊢ 3 = 4",
+    "endPos": {"line": 2, "column": 19}},
+   {"usedConstants":
+    ["sorryAx", "instOfNatNat", "Nat", "OfNat.ofNat", "Bool.false", "Eq"],
+    "tactic": "sorry",
+-   "proofState": 5,
++   "proofState": 4,
+    "pos": {"line": 3, "column": 14},
+    "goals": "⊢ 4 = 5",
+    "endPos": {"line": 3, "column": 19}}],

--- a/versions/v4.11.0.diff
+++ b/versions/v4.11.0.diff
@@ -1,0 +1,387 @@
+diff --git a/REPL/Frontend.lean b/REPL/Frontend.lean
+index 9cc0914..a2bb150 100644
+--- a/REPL/Frontend.lean
++++ b/REPL/Frontend.lean
+@@ -20,7 +20,10 @@ def processCommandsWithInfoTrees
+     (commandState : Command.State) : IO (Command.State × List Message × List InfoTree) := do
+   let commandState := { commandState with infoState.enabled := true }
+   let s ← IO.processCommands inputCtx parserState commandState <&> Frontend.State.commandState
+-  pure (s, s.messages.toList, s.infoState.trees.toList)
++  let msgs := s.messages.toList.drop commandState.messages.toList.length
++  let trees := s.infoState.trees.toList.drop commandState.infoState.trees.size
++
++  pure (s, msgs, trees)
+ 
+ /--
+ Process some text input, with or without an existing command state.
+diff --git a/REPL/JSON.lean b/REPL/JSON.lean
+index d5c5ba2..b63c5ea 100644
+--- a/REPL/JSON.lean
++++ b/REPL/JSON.lean
+@@ -83,7 +83,7 @@ structure Sorry where
+ deriving FromJson
+ 
+ instance : ToJson Sorry where
+-  toJson r := Json.mkObj <| .flatten [
++  toJson r := Json.mkObj <| .join [
+     [("goal", r.goal)],
+     [("proofState", toJson r.proofState)],
+     if r.pos.line ≠ 0 then [("pos", toJson r.pos)] else [],
+@@ -132,7 +132,7 @@ def Json.nonemptyList [ToJson α] (k : String) : List α → List (String × Jso
+   | l  => [⟨k, toJson l⟩]
+ 
+ instance : ToJson CommandResponse where
+-  toJson r := Json.mkObj <| .flatten [
++  toJson r := Json.mkObj <| .join [
+     [("env", r.env)],
+     Json.nonemptyList "messages" r.messages,
+     Json.nonemptyList "sorries" r.sorries,
+@@ -153,7 +153,7 @@ structure ProofStepResponse where
+ deriving ToJson, FromJson
+ 
+ instance : ToJson ProofStepResponse where
+-  toJson r := Json.mkObj <| .flatten [
++  toJson r := Json.mkObj <| .join [
+     [("proofState", r.proofState)],
+     [("goals", toJson r.goals)],
+     Json.nonemptyList "messages" r.messages,
+diff --git a/REPL/Lean/Environment.lean b/REPL/Lean/Environment.lean
+index 0b4be3c..61d4e76 100644
+--- a/REPL/Lean/Environment.lean
++++ b/REPL/Lean/Environment.lean
+@@ -26,6 +26,6 @@ and then replace the new constants.
+ def unpickle (path : FilePath) : IO (Environment × CompactedRegion) := unsafe do
+   let ((imports, map₂), region) ← _root_.unpickle (Array Import × PHashMap Name ConstantInfo) path
+   let env ← importModules imports {} 0
+-  return (← env.replay (Std.HashMap.ofList map₂.toList), region)
++  return (← env.replay (HashMap.ofList map₂.toList), region)
+ 
+ end Lean.Environment
+diff --git a/REPL/Lean/InfoTree.lean b/REPL/Lean/InfoTree.lean
+index 7abf0b8..d3b28c1 100644
+--- a/REPL/Lean/InfoTree.lean
++++ b/REPL/Lean/InfoTree.lean
+@@ -131,9 +131,9 @@ partial def filter (p : Info → Bool) (m : MVarId → Bool := fun _ => false) :
+   | .context ctx tree => tree.filter p m |>.map (.context ctx)
+   | .node info children =>
+     if p info then
+-      [.node info (children.toList.map (filter p m)).flatten.toPArray']
++      [.node info (children.toList.map (filter p m)).join.toPArray']
+     else
+-      (children.toList.map (filter p m)).flatten
++      (children.toList.map (filter p m)).join
+   | .hole mvar => if m mvar then [.hole mvar] else []
+ 
+ /-- Discard all nodes besides `.context` nodes and `TacticInfo` nodes. -/
+@@ -156,7 +156,7 @@ partial def findAllInfo (t : InfoTree) (ctx? : Option ContextInfo) (p : Info →
+   | context ctx t => t.findAllInfo (ctx.mergeIntoOuter? ctx?) p
+   | node i ts  =>
+     let info := if p i then [(i, ctx?)] else []
+-    let rest := ts.toList.flatMap (fun t => t.findAllInfo ctx? p)
++    let rest := ts.toList.bind (fun t => t.findAllInfo ctx? p)
+     info ++ rest
+   | _ => []
+ 
+@@ -214,13 +214,13 @@ def sorries (t : InfoTree) : List (ContextInfo × SorryType × Position × Posit
+ 
+ def tactics (t : InfoTree) : List (ContextInfo × Syntax × List MVarId × Position × Position × Array Name) :=
+     -- HACK: creating a child ngen
+-  t.findTacticNodes.map fun ⟨i, ctx⟩ => 
+-    let range := stxRange ctx.fileMap i.stx 
+-    ( { ctx with mctx := i.mctxBefore, ngen := ctx.ngen.mkChild.1 }, 
+-      i.stx, 
+-      i.goalsBefore, 
+-      range.fst, 
+-      range.snd, 
++  t.findTacticNodes.map fun ⟨i, ctx⟩ =>
++    let range := stxRange ctx.fileMap i.stx
++    ( { ctx with mctx := i.mctxBefore, ngen := ctx.ngen.mkChild.1 },
++      i.stx,
++      i.goalsBefore,
++      range.fst,
++      range.snd,
+       i.getUsedConstantsAsSet.toArray )
+ 
+ 
+diff --git a/REPL/Main.lean b/REPL/Main.lean
+index a4b97c3..8211b8c 100644
+--- a/REPL/Main.lean
++++ b/REPL/Main.lean
+@@ -95,7 +95,7 @@ def recordProofSnapshot (proofState : ProofSnapshot) : M m Nat := do
+   return id
+ 
+ def sorries (trees : List InfoTree) (env? : Option Environment) : M m (List Sorry) :=
+-  trees.flatMap InfoTree.sorries |>.filter (fun t => match t.2.1 with
++  trees.bind InfoTree.sorries |>.filter (fun t => match t.2.1 with
+     | .term _ none => false
+     | _ => true ) |>.mapM
+       fun ⟨ctx, g, pos, endPos⟩ => do
+@@ -117,7 +117,7 @@ def ppTactic (ctx : ContextInfo) (stx : Syntax) : IO Format :=
+     pure "<failed to pretty print>"
+ 
+ def tactics (trees : List InfoTree) : M m (List Tactic) :=
+-  trees.flatMap InfoTree.tactics |>.mapM
++  trees.bind InfoTree.tactics |>.mapM
+     fun ⟨ctx, stx, goals, pos, endPos, ns⟩ => do
+       let proofState := some (← ProofSnapshot.create ctx none none goals)
+       let goals := s!"{(← ctx.ppGoals goals)}".trim
+@@ -218,9 +218,9 @@ def runCommand (s : Command) : M IO (CommandResponse ⊕ Error) := do
+   let env ← recordCommandSnapshot cmdSnapshot
+   let jsonTrees := match s.infotree with
+   | some "full" => trees
+-  | some "tactics" => trees.flatMap InfoTree.retainTacticInfo
+-  | some "original" => trees.flatMap InfoTree.retainTacticInfo |>.flatMap InfoTree.retainOriginal
+-  | some "substantive" => trees.flatMap InfoTree.retainTacticInfo |>.flatMap InfoTree.retainSubstantive
++  | some "tactics" => trees.bind InfoTree.retainTacticInfo
++  | some "original" => trees.bind InfoTree.retainTacticInfo |>.bind InfoTree.retainOriginal
++  | some "substantive" => trees.bind InfoTree.retainTacticInfo |>.bind InfoTree.retainSubstantive
+   | _ => []
+   let infotree ← if jsonTrees.isEmpty then
+     pure none
+diff --git a/REPL/Snapshots.lean b/REPL/Snapshots.lean
+index 1114c24..7462141 100644
+--- a/REPL/Snapshots.lean
++++ b/REPL/Snapshots.lean
+@@ -83,7 +83,7 @@ def unpickle (path : FilePath) : IO (CommandSnapshot × CompactedRegion) := unsa
+   let ((imports, map₂, cmdState, cmdContext), region) ←
+     _root_.unpickle (Array Import × PHashMap Name ConstantInfo × CompactableCommandSnapshot ×
+       Command.Context) path
+-  let env ← (← importModules imports {} 0).replay (Std.HashMap.ofList map₂.toList)
++  let env ← (← importModules imports {} 0).replay (HashMap.ofList map₂.toList)
+   let p' : CommandSnapshot :=
+   { cmdState := { cmdState with env }
+     cmdContext }
+@@ -284,9 +284,9 @@ def unpickle (path : FilePath) (cmd? : Option CommandSnapshot) :
+   let env ← match cmd? with
+   | none =>
+     enableInitializersExecution
+-    (← importModules imports {} 0).replay (Std.HashMap.ofList map₂.toList)
++    (← importModules imports {} 0).replay (HashMap.ofList map₂.toList)
+   | some cmd =>
+-    cmd.cmdState.env.replay (Std.HashMap.ofList map₂.toList)
++    cmd.cmdState.env.replay (HashMap.ofList map₂.toList)
+   let p' : ProofSnapshot :=
+   { coreState := { coreState with env }
+     coreContext
+diff --git a/lean-toolchain b/lean-toolchain
+index 1e70935..5a9c76d 100644
+--- a/lean-toolchain
++++ b/lean-toolchain
+@@ -1 +1 @@
+-leanprover/lean4:v4.14.0
++leanprover/lean4:v4.11.0
+diff --git a/test/Mathlib/lake-manifest.json b/test/Mathlib/lake-manifest.json
+index f312e5a..818bb5a 100644
+--- a/test/Mathlib/lake-manifest.json
++++ b/test/Mathlib/lake-manifest.json
+@@ -1,95 +1,75 @@
+ {"version": "1.1.0",
+  "packagesDir": ".lake/packages",
+  "packages":
+- [{"url": "https://github.com/leanprover-community/mathlib4",
+-   "type": "git",
+-   "subDir": null,
+-   "scope": "",
+-   "rev": "4bbdccd9c5f862bf90ff12f0a9e2c8be032b9a84",
+-   "name": "mathlib",
+-   "manifestFile": "lake-manifest.json",
+-   "inputRev": "v4.14.0",
+-   "inherited": false,
+-   "configFile": "lakefile.lean"},
+-  {"url": "https://github.com/leanprover-community/plausible",
++ [{"url": "https://github.com/leanprover-community/batteries",
+    "type": "git",
+    "subDir": null,
+    "scope": "leanprover-community",
+-   "rev": "42dc02bdbc5d0c2f395718462a76c3d87318f7fa",
+-   "name": "plausible",
++   "rev": "9c6c2d647e57b2b7a0b42dd8080c698bd33a1b6f",
++   "name": "batteries",
+    "manifestFile": "lake-manifest.json",
+    "inputRev": "main",
+    "inherited": true,
+-   "configFile": "lakefile.toml"},
+-  {"url": "https://github.com/leanprover-community/LeanSearchClient",
++   "configFile": "lakefile.lean"},
++  {"url": "https://github.com/leanprover-community/quote4",
+    "type": "git",
+    "subDir": null,
+    "scope": "leanprover-community",
+-   "rev": "d7caecce0d0f003fd5e9cce9a61f1dd6ba83142b",
+-   "name": "LeanSearchClient",
++   "rev": "9d0bdd07bdfe53383567509348b1fe917fc08de4",
++   "name": "Qq",
+    "manifestFile": "lake-manifest.json",
+-   "inputRev": "main",
++   "inputRev": "master",
+    "inherited": true,
+-   "configFile": "lakefile.toml"},
+-  {"url": "https://github.com/leanprover-community/import-graph",
++   "configFile": "lakefile.lean"},
++  {"url": "https://github.com/leanprover-community/aesop",
+    "type": "git",
+    "subDir": null,
+    "scope": "leanprover-community",
+-   "rev": "519e509a28864af5bed98033dd33b95cf08e9aa7",
+-   "name": "importGraph",
++   "rev": "deb279eb7be16848d0bc8387f80d6e41bcdbe738",
++   "name": "aesop",
+    "manifestFile": "lake-manifest.json",
+-   "inputRev": "v4.14.0",
++   "inputRev": "master",
+    "inherited": true,
+    "configFile": "lakefile.toml"},
+   {"url": "https://github.com/leanprover-community/ProofWidgets4",
+    "type": "git",
+    "subDir": null,
+    "scope": "leanprover-community",
+-   "rev": "68280daef58803f68368eb2e53046dabcd270c9d",
++   "rev": "a96aee5245720f588876021b6a0aa73efee49c76",
+    "name": "proofwidgets",
+    "manifestFile": "lake-manifest.json",
+-   "inputRev": "v0.0.47",
++   "inputRev": "v0.0.41",
+    "inherited": true,
+    "configFile": "lakefile.lean"},
+-  {"url": "https://github.com/leanprover-community/aesop",
++  {"url": "https://github.com/leanprover/lean4-cli",
+    "type": "git",
+    "subDir": null,
+-   "scope": "leanprover-community",
+-   "rev": "5a0ec8588855265ade536f35bcdcf0fb24fd6030",
+-   "name": "aesop",
++   "scope": "",
++   "rev": "2cf1030dc2ae6b3632c84a09350b675ef3e347d0",
++   "name": "Cli",
+    "manifestFile": "lake-manifest.json",
+-   "inputRev": "v4.14.0",
++   "inputRev": "main",
+    "inherited": true,
+    "configFile": "lakefile.toml"},
+-  {"url": "https://github.com/leanprover-community/quote4",
+-   "type": "git",
+-   "subDir": null,
+-   "scope": "leanprover-community",
+-   "rev": "303b23fbcea94ac4f96e590c1cad6618fd4f5f41",
+-   "name": "Qq",
+-   "manifestFile": "lake-manifest.json",
+-   "inputRev": "master",
+-   "inherited": true,
+-   "configFile": "lakefile.lean"},
+-  {"url": "https://github.com/leanprover-community/batteries",
++  {"url": "https://github.com/leanprover-community/import-graph",
+    "type": "git",
+    "subDir": null,
+    "scope": "leanprover-community",
+-   "rev": "8d6c853f11a5172efa0e96b9f2be1a83d861cdd9",
+-   "name": "batteries",
++   "rev": "1ef0b288623337cb37edd1222b9c26b4b77c6620",
++   "name": "importGraph",
+    "manifestFile": "lake-manifest.json",
+-   "inputRev": "v4.14.0",
++   "inputRev": "main",
+    "inherited": true,
+    "configFile": "lakefile.toml"},
+-  {"url": "https://github.com/leanprover/lean4-cli",
++  {"url": "https://github.com/leanprover-community/mathlib4",
+    "type": "git",
+    "subDir": null,
+-   "scope": "leanprover",
+-   "rev": "726b3c9ad13acca724d4651f14afc4804a7b0e4d",
+-   "name": "Cli",
++   "scope": "",
++   "rev": "8edf04f0977c3183d3b633792e03fd570be1777f",
++   "name": "mathlib",
+    "manifestFile": "lake-manifest.json",
+-   "inputRev": "main",
+-   "inherited": true,
+-   "configFile": "lakefile.toml"}],
++   "inputRev": "master",
++   "inherited": false,
++   "configFile": "lakefile.lean"}],
+  "name": "«repl-mathlib-tests»",
+  "lakeDir": ".lake"}
+diff --git a/test/Mathlib/lakefile.toml b/test/Mathlib/lakefile.toml
+index 6ff9631..af41e27 100644
+--- a/test/Mathlib/lakefile.toml
++++ b/test/Mathlib/lakefile.toml
+@@ -1,11 +1,11 @@
+-name = "«repl-mathlib-tests»"
++name           = "«repl-mathlib-tests»"
+ defaultTargets = ["ReplMathlibTests"]
+ 
+ [[require]]
+ name = "mathlib"
+-git = "https://github.com/leanprover-community/mathlib4"
+-rev = "v4.14.0"
++git  = "https://github.com/leanprover-community/mathlib4"
++rev  = "master"
+ 
+ [[lean_lib]]
+-name = "ReplMathlibTests"
++name  = "ReplMathlibTests"
+ globs = ["test.+"]
+diff --git a/test/Mathlib/lean-toolchain b/test/Mathlib/lean-toolchain
+index 401bc14..5a9c76d 100644
+--- a/test/Mathlib/lean-toolchain
++++ b/test/Mathlib/lean-toolchain
+@@ -1 +1 @@
+-leanprover/lean4:v4.14.0
+\ No newline at end of file
++leanprover/lean4:v4.11.0
+diff --git a/test/all_tactics.expected.out b/test/all_tactics.expected.out
+index 6ec808c..5374db8 100644
+--- a/test/all_tactics.expected.out
++++ b/test/all_tactics.expected.out
+@@ -9,7 +9,7 @@
+    "tactic": "exact t",
+    "proofState": 1,
+    "pos": {"line": 1, "column": 32},
+-   "goals": "t : Nat\n⊢ Nat",
++   "goals": "t : Nat ⊢ Nat",
+    "endPos": {"line": 1, "column": 39}}],
+  "env": 0}
+ 
+diff --git a/test/calc.expected.out b/test/calc.expected.out
+index 94f6a9f..fde8fee 100644
+--- a/test/calc.expected.out
++++ b/test/calc.expected.out
+@@ -1,35 +1,22 @@
+ {"tactics":
+  [{"usedConstants":
+-   ["Trans.trans",
+-    "sorryAx",
+-    "instOfNatNat",
+-    "instTransEq",
+-    "Nat",
+-    "OfNat.ofNat",
+-    "Bool.false",
+-    "Eq"],
++   ["Trans.trans", "instOfNatNat", "instTransEq", "Nat", "OfNat.ofNat", "Eq"],
+    "tactic": "calc\n  3 = 4 := by sorry\n  4 = 5 := by sorry",
+    "proofState": 2,
+    "pos": {"line": 1, "column": 22},
+    "goals": "⊢ 3 = 5",
+    "endPos": {"line": 3, "column": 19}},
+-  {"usedConstants": [],
+-   "tactic": "\n  3 = 4 := by sorry\n  4 = 5 := by sorry",
+-   "proofState": 3,
+-   "pos": {"line": 2, "column": 2},
+-   "goals": "no goals",
+-   "endPos": {"line": 3, "column": 19}},
+   {"usedConstants":
+    ["sorryAx", "instOfNatNat", "Nat", "OfNat.ofNat", "Bool.false", "Eq"],
+    "tactic": "sorry",
+-   "proofState": 4,
++   "proofState": 3,
+    "pos": {"line": 2, "column": 14},
+    "goals": "⊢ 3 = 4",
+    "endPos": {"line": 2, "column": 19}},
+   {"usedConstants":
+    ["sorryAx", "instOfNatNat", "Nat", "OfNat.ofNat", "Bool.false", "Eq"],
+    "tactic": "sorry",
+-   "proofState": 5,
++   "proofState": 4,
+    "pos": {"line": 3, "column": 14},
+    "goals": "⊢ 4 = 5",
+    "endPos": {"line": 3, "column": 19}}],

--- a/versions/v4.12.0-rc1.diff
+++ b/versions/v4.12.0-rc1.diff
@@ -134,169 +134,26 @@ index a4b97c3..32702be 100644
    let infotree ← if jsonTrees.isEmpty then
      pure none
 diff --git a/lean-toolchain b/lean-toolchain
-index 1e70935..8998520 100644
+index 1e70935..98556ba 100644
 --- a/lean-toolchain
 +++ b/lean-toolchain
 @@ -1 +1 @@
 -leanprover/lean4:v4.14.0
-+leanprover/lean4:v4.12.0
-diff --git a/test/Mathlib/lake-manifest.json b/test/Mathlib/lake-manifest.json
-index f312e5a..34f725d 100644
---- a/test/Mathlib/lake-manifest.json
-+++ b/test/Mathlib/lake-manifest.json
-@@ -1,95 +1,85 @@
- {"version": "1.1.0",
-  "packagesDir": ".lake/packages",
-  "packages":
-- [{"url": "https://github.com/leanprover-community/mathlib4",
--   "type": "git",
--   "subDir": null,
--   "scope": "",
--   "rev": "4bbdccd9c5f862bf90ff12f0a9e2c8be032b9a84",
--   "name": "mathlib",
--   "manifestFile": "lake-manifest.json",
--   "inputRev": "v4.14.0",
--   "inherited": false,
--   "configFile": "lakefile.lean"},
--  {"url": "https://github.com/leanprover-community/plausible",
-+ [{"url": "https://github.com/leanprover-community/batteries",
-    "type": "git",
-    "subDir": null,
-    "scope": "leanprover-community",
--   "rev": "42dc02bdbc5d0c2f395718462a76c3d87318f7fa",
--   "name": "plausible",
-+   "rev": "4756e0fc48acce0cc808df0ad149de5973240df6",
-+   "name": "batteries",
-    "manifestFile": "lake-manifest.json",
-    "inputRev": "main",
-    "inherited": true,
--   "configFile": "lakefile.toml"},
--  {"url": "https://github.com/leanprover-community/LeanSearchClient",
-+   "configFile": "lakefile.lean"},
-+  {"url": "https://github.com/leanprover-community/quote4",
-    "type": "git",
-    "subDir": null,
-    "scope": "leanprover-community",
--   "rev": "d7caecce0d0f003fd5e9cce9a61f1dd6ba83142b",
--   "name": "LeanSearchClient",
-+   "rev": "2c8ae451ce9ffc83554322b14437159c1a9703f9",
-+   "name": "Qq",
-    "manifestFile": "lake-manifest.json",
--   "inputRev": "main",
-+   "inputRev": "master",
-    "inherited": true,
--   "configFile": "lakefile.toml"},
--  {"url": "https://github.com/leanprover-community/import-graph",
-+   "configFile": "lakefile.lean"},
-+  {"url": "https://github.com/leanprover-community/aesop",
-    "type": "git",
-    "subDir": null,
-    "scope": "leanprover-community",
--   "rev": "519e509a28864af5bed98033dd33b95cf08e9aa7",
--   "name": "importGraph",
-+   "rev": "28fa80508edc97d96ed6342c9a771a67189e0baa",
-+   "name": "aesop",
-    "manifestFile": "lake-manifest.json",
--   "inputRev": "v4.14.0",
-+   "inputRev": "master",
-    "inherited": true,
-    "configFile": "lakefile.toml"},
-   {"url": "https://github.com/leanprover-community/ProofWidgets4",
-    "type": "git",
-    "subDir": null,
-    "scope": "leanprover-community",
--   "rev": "68280daef58803f68368eb2e53046dabcd270c9d",
-+   "rev": "eb08eee94098fe530ccd6d8751a86fe405473d4c",
-    "name": "proofwidgets",
-    "manifestFile": "lake-manifest.json",
--   "inputRev": "v0.0.47",
-+   "inputRev": "v0.0.42",
-    "inherited": true,
-    "configFile": "lakefile.lean"},
--  {"url": "https://github.com/leanprover-community/aesop",
-+  {"url": "https://github.com/leanprover/lean4-cli",
-    "type": "git",
-    "subDir": null,
--   "scope": "leanprover-community",
--   "rev": "5a0ec8588855265ade536f35bcdcf0fb24fd6030",
--   "name": "aesop",
-+   "scope": "",
-+   "rev": "2cf1030dc2ae6b3632c84a09350b675ef3e347d0",
-+   "name": "Cli",
-    "manifestFile": "lake-manifest.json",
--   "inputRev": "v4.14.0",
-+   "inputRev": "main",
-    "inherited": true,
-    "configFile": "lakefile.toml"},
--  {"url": "https://github.com/leanprover-community/quote4",
-+  {"url": "https://github.com/leanprover-community/import-graph",
-    "type": "git",
-    "subDir": null,
-    "scope": "leanprover-community",
--   "rev": "303b23fbcea94ac4f96e590c1cad6618fd4f5f41",
--   "name": "Qq",
-+   "rev": "e285a7ade149c551c17a4b24f127e1ef782e4bb1",
-+   "name": "importGraph",
-    "manifestFile": "lake-manifest.json",
--   "inputRev": "master",
-+   "inputRev": "main",
-    "inherited": true,
--   "configFile": "lakefile.lean"},
--  {"url": "https://github.com/leanprover-community/batteries",
-+   "configFile": "lakefile.toml"},
-+  {"url": "https://github.com/leanprover-community/LeanSearchClient",
-    "type": "git",
-    "subDir": null,
-    "scope": "leanprover-community",
--   "rev": "8d6c853f11a5172efa0e96b9f2be1a83d861cdd9",
--   "name": "batteries",
-+   "rev": "2ba60fa2c384a94735454db11a2d523612eaabff",
-+   "name": "LeanSearchClient",
-    "manifestFile": "lake-manifest.json",
--   "inputRev": "v4.14.0",
-+   "inputRev": "main",
-    "inherited": true,
-    "configFile": "lakefile.toml"},
--  {"url": "https://github.com/leanprover/lean4-cli",
-+  {"url": "https://github.com/leanprover-community/mathlib4",
-    "type": "git",
-    "subDir": null,
--   "scope": "leanprover",
--   "rev": "726b3c9ad13acca724d4651f14afc4804a7b0e4d",
--   "name": "Cli",
-+   "scope": "",
-+   "rev": "809c3fb3b5c8f5d7dace56e200b426187516535a",
-+   "name": "mathlib",
-    "manifestFile": "lake-manifest.json",
--   "inputRev": "main",
--   "inherited": true,
--   "configFile": "lakefile.toml"}],
-+   "inputRev": "v4.12.0",
-+   "inherited": false,
-+   "configFile": "lakefile.lean"}],
-  "name": "«repl-mathlib-tests»",
-  "lakeDir": ".lake"}
-diff --git a/test/Mathlib/lakefile.toml b/test/Mathlib/lakefile.toml
-index 6ff9631..daea648 100644
---- a/test/Mathlib/lakefile.toml
-+++ b/test/Mathlib/lakefile.toml
-@@ -4,7 +4,7 @@ defaultTargets = ["ReplMathlibTests"]
- [[require]]
- name = "mathlib"
- git = "https://github.com/leanprover-community/mathlib4"
--rev = "v4.14.0"
-+rev = "v4.12.0"
++leanprover/lean4:v4.12.0-rc1
+diff --git a/test.sh b/test.sh
+index 070ce3d..ee98867 100755
+--- a/test.sh
++++ b/test.sh
+@@ -41,6 +41,6 @@ for infile in $IN_DIR/*.in; do
  
- [[lean_lib]]
- name = "ReplMathlibTests"
-diff --git a/test/Mathlib/lean-toolchain b/test/Mathlib/lean-toolchain
-index 401bc14..8998520 100644
---- a/test/Mathlib/lean-toolchain
-+++ b/test/Mathlib/lean-toolchain
-@@ -1 +1 @@
--leanprover/lean4:v4.14.0
-\ No newline at end of file
-+leanprover/lean4:v4.12.0
+ done
+ 
+-# Run the Mathlib tests
+-cp lean-toolchain test/Mathlib/
+-cd test/Mathlib/ && ./test.sh
++# Run the Mathlib tests - skipped as no Mathlib releases exist for v4.12.0-rc1
++# cp lean-toolchain test/Mathlib/
++# cd test/Mathlib/ && ./test.sh
 diff --git a/test/all_tactics.expected.out b/test/all_tactics.expected.out
 index 6ec808c..5374db8 100644
 --- a/test/all_tactics.expected.out

--- a/versions/v4.12.0.diff
+++ b/versions/v4.12.0.diff
@@ -1,0 +1,362 @@
+diff --git a/REPL/JSON.lean b/REPL/JSON.lean
+index d5c5ba2..b63c5ea 100644
+--- a/REPL/JSON.lean
++++ b/REPL/JSON.lean
+@@ -83,7 +83,7 @@ structure Sorry where
+ deriving FromJson
+ 
+ instance : ToJson Sorry where
+-  toJson r := Json.mkObj <| .flatten [
++  toJson r := Json.mkObj <| .join [
+     [("goal", r.goal)],
+     [("proofState", toJson r.proofState)],
+     if r.pos.line ≠ 0 then [("pos", toJson r.pos)] else [],
+@@ -132,7 +132,7 @@ def Json.nonemptyList [ToJson α] (k : String) : List α → List (String × Jso
+   | l  => [⟨k, toJson l⟩]
+ 
+ instance : ToJson CommandResponse where
+-  toJson r := Json.mkObj <| .flatten [
++  toJson r := Json.mkObj <| .join [
+     [("env", r.env)],
+     Json.nonemptyList "messages" r.messages,
+     Json.nonemptyList "sorries" r.sorries,
+@@ -153,7 +153,7 @@ structure ProofStepResponse where
+ deriving ToJson, FromJson
+ 
+ instance : ToJson ProofStepResponse where
+-  toJson r := Json.mkObj <| .flatten [
++  toJson r := Json.mkObj <| .join [
+     [("proofState", r.proofState)],
+     [("goals", toJson r.goals)],
+     Json.nonemptyList "messages" r.messages,
+diff --git a/REPL/Lean/InfoTree.lean b/REPL/Lean/InfoTree.lean
+index 7abf0b8..d3b28c1 100644
+--- a/REPL/Lean/InfoTree.lean
++++ b/REPL/Lean/InfoTree.lean
+@@ -131,9 +131,9 @@ partial def filter (p : Info → Bool) (m : MVarId → Bool := fun _ => false) :
+   | .context ctx tree => tree.filter p m |>.map (.context ctx)
+   | .node info children =>
+     if p info then
+-      [.node info (children.toList.map (filter p m)).flatten.toPArray']
++      [.node info (children.toList.map (filter p m)).join.toPArray']
+     else
+-      (children.toList.map (filter p m)).flatten
++      (children.toList.map (filter p m)).join
+   | .hole mvar => if m mvar then [.hole mvar] else []
+ 
+ /-- Discard all nodes besides `.context` nodes and `TacticInfo` nodes. -/
+@@ -156,7 +156,7 @@ partial def findAllInfo (t : InfoTree) (ctx? : Option ContextInfo) (p : Info →
+   | context ctx t => t.findAllInfo (ctx.mergeIntoOuter? ctx?) p
+   | node i ts  =>
+     let info := if p i then [(i, ctx?)] else []
+-    let rest := ts.toList.flatMap (fun t => t.findAllInfo ctx? p)
++    let rest := ts.toList.bind (fun t => t.findAllInfo ctx? p)
+     info ++ rest
+   | _ => []
+ 
+@@ -214,13 +214,13 @@ def sorries (t : InfoTree) : List (ContextInfo × SorryType × Position × Posit
+ 
+ def tactics (t : InfoTree) : List (ContextInfo × Syntax × List MVarId × Position × Position × Array Name) :=
+     -- HACK: creating a child ngen
+-  t.findTacticNodes.map fun ⟨i, ctx⟩ => 
+-    let range := stxRange ctx.fileMap i.stx 
+-    ( { ctx with mctx := i.mctxBefore, ngen := ctx.ngen.mkChild.1 }, 
+-      i.stx, 
+-      i.goalsBefore, 
+-      range.fst, 
+-      range.snd, 
++  t.findTacticNodes.map fun ⟨i, ctx⟩ =>
++    let range := stxRange ctx.fileMap i.stx
++    ( { ctx with mctx := i.mctxBefore, ngen := ctx.ngen.mkChild.1 },
++      i.stx,
++      i.goalsBefore,
++      range.fst,
++      range.snd,
+       i.getUsedConstantsAsSet.toArray )
+ 
+ 
+diff --git a/REPL/Main.lean b/REPL/Main.lean
+index a4b97c3..32702be 100644
+--- a/REPL/Main.lean
++++ b/REPL/Main.lean
+@@ -95,7 +95,7 @@ def recordProofSnapshot (proofState : ProofSnapshot) : M m Nat := do
+   return id
+ 
+ def sorries (trees : List InfoTree) (env? : Option Environment) : M m (List Sorry) :=
+-  trees.flatMap InfoTree.sorries |>.filter (fun t => match t.2.1 with
++  trees.bind InfoTree.sorries |>.filter (fun t => match t.2.1 with
+     | .term _ none => false
+     | _ => true ) |>.mapM
+       fun ⟨ctx, g, pos, endPos⟩ => do
+@@ -117,7 +117,7 @@ def ppTactic (ctx : ContextInfo) (stx : Syntax) : IO Format :=
+     pure "<failed to pretty print>"
+ 
+ def tactics (trees : List InfoTree) : M m (List Tactic) :=
+-  trees.flatMap InfoTree.tactics |>.mapM
++  trees.bind InfoTree.tactics |>.mapM
+     fun ⟨ctx, stx, goals, pos, endPos, ns⟩ => do
+       let proofState := some (← ProofSnapshot.create ctx none none goals)
+       let goals := s!"{(← ctx.ppGoals goals)}".trim
+@@ -184,6 +184,14 @@ def unpickleProofSnapshot (n : UnpickleProofState) : M IO (ProofStepResponse ⊕
+   let (proofState, _) ← ProofSnapshot.unpickle n.unpickleProofStateFrom cmdSnapshot?
+   Sum.inl <$> createProofStepReponse proofState
+ 
++partial def filterRootTactics (tree : InfoTree) : Bool :=
++  match tree with
++  | InfoTree.hole _     => true
++  | InfoTree.context _ t => filterRootTactics t
++  | InfoTree.node i _   => match i with
++      | .ofTacticInfo _ => false
++      | _ => true
++
+ /--
+ Run a command, returning the id of the new environment, and any messages and sorries.
+ -/
+@@ -201,6 +209,7 @@ def runCommand (s : Command) : M IO (CommandResponse ⊕ Error) := do
+   catch ex =>
+     return .inr ⟨ex.toString⟩
+   let messages ← messages.mapM fun m => Message.of m
++  let trees := trees.filter filterRootTactics
+   -- For debugging purposes, sometimes we print out the trees here:
+   -- trees.forM fun t => do IO.println (← t.format)
+   let sorries ← sorries trees (initialCmdState?.map (·.env))
+@@ -218,9 +227,9 @@ def runCommand (s : Command) : M IO (CommandResponse ⊕ Error) := do
+   let env ← recordCommandSnapshot cmdSnapshot
+   let jsonTrees := match s.infotree with
+   | some "full" => trees
+-  | some "tactics" => trees.flatMap InfoTree.retainTacticInfo
+-  | some "original" => trees.flatMap InfoTree.retainTacticInfo |>.flatMap InfoTree.retainOriginal
+-  | some "substantive" => trees.flatMap InfoTree.retainTacticInfo |>.flatMap InfoTree.retainSubstantive
++  | some "tactics" => trees.bind InfoTree.retainTacticInfo
++  | some "original" => trees.bind InfoTree.retainTacticInfo |>.bind InfoTree.retainOriginal
++  | some "substantive" => trees.bind InfoTree.retainTacticInfo |>.bind InfoTree.retainSubstantive
+   | _ => []
+   let infotree ← if jsonTrees.isEmpty then
+     pure none
+diff --git a/lean-toolchain b/lean-toolchain
+index 1e70935..8998520 100644
+--- a/lean-toolchain
++++ b/lean-toolchain
+@@ -1 +1 @@
+-leanprover/lean4:v4.14.0
++leanprover/lean4:v4.12.0
+diff --git a/test/Mathlib/lake-manifest.json b/test/Mathlib/lake-manifest.json
+index f312e5a..34f725d 100644
+--- a/test/Mathlib/lake-manifest.json
++++ b/test/Mathlib/lake-manifest.json
+@@ -1,95 +1,85 @@
+ {"version": "1.1.0",
+  "packagesDir": ".lake/packages",
+  "packages":
+- [{"url": "https://github.com/leanprover-community/mathlib4",
+-   "type": "git",
+-   "subDir": null,
+-   "scope": "",
+-   "rev": "4bbdccd9c5f862bf90ff12f0a9e2c8be032b9a84",
+-   "name": "mathlib",
+-   "manifestFile": "lake-manifest.json",
+-   "inputRev": "v4.14.0",
+-   "inherited": false,
+-   "configFile": "lakefile.lean"},
+-  {"url": "https://github.com/leanprover-community/plausible",
++ [{"url": "https://github.com/leanprover-community/batteries",
+    "type": "git",
+    "subDir": null,
+    "scope": "leanprover-community",
+-   "rev": "42dc02bdbc5d0c2f395718462a76c3d87318f7fa",
+-   "name": "plausible",
++   "rev": "4756e0fc48acce0cc808df0ad149de5973240df6",
++   "name": "batteries",
+    "manifestFile": "lake-manifest.json",
+    "inputRev": "main",
+    "inherited": true,
+-   "configFile": "lakefile.toml"},
+-  {"url": "https://github.com/leanprover-community/LeanSearchClient",
++   "configFile": "lakefile.lean"},
++  {"url": "https://github.com/leanprover-community/quote4",
+    "type": "git",
+    "subDir": null,
+    "scope": "leanprover-community",
+-   "rev": "d7caecce0d0f003fd5e9cce9a61f1dd6ba83142b",
+-   "name": "LeanSearchClient",
++   "rev": "2c8ae451ce9ffc83554322b14437159c1a9703f9",
++   "name": "Qq",
+    "manifestFile": "lake-manifest.json",
+-   "inputRev": "main",
++   "inputRev": "master",
+    "inherited": true,
+-   "configFile": "lakefile.toml"},
+-  {"url": "https://github.com/leanprover-community/import-graph",
++   "configFile": "lakefile.lean"},
++  {"url": "https://github.com/leanprover-community/aesop",
+    "type": "git",
+    "subDir": null,
+    "scope": "leanprover-community",
+-   "rev": "519e509a28864af5bed98033dd33b95cf08e9aa7",
+-   "name": "importGraph",
++   "rev": "28fa80508edc97d96ed6342c9a771a67189e0baa",
++   "name": "aesop",
+    "manifestFile": "lake-manifest.json",
+-   "inputRev": "v4.14.0",
++   "inputRev": "master",
+    "inherited": true,
+    "configFile": "lakefile.toml"},
+   {"url": "https://github.com/leanprover-community/ProofWidgets4",
+    "type": "git",
+    "subDir": null,
+    "scope": "leanprover-community",
+-   "rev": "68280daef58803f68368eb2e53046dabcd270c9d",
++   "rev": "eb08eee94098fe530ccd6d8751a86fe405473d4c",
+    "name": "proofwidgets",
+    "manifestFile": "lake-manifest.json",
+-   "inputRev": "v0.0.47",
++   "inputRev": "v0.0.42",
+    "inherited": true,
+    "configFile": "lakefile.lean"},
+-  {"url": "https://github.com/leanprover-community/aesop",
++  {"url": "https://github.com/leanprover/lean4-cli",
+    "type": "git",
+    "subDir": null,
+-   "scope": "leanprover-community",
+-   "rev": "5a0ec8588855265ade536f35bcdcf0fb24fd6030",
+-   "name": "aesop",
++   "scope": "",
++   "rev": "2cf1030dc2ae6b3632c84a09350b675ef3e347d0",
++   "name": "Cli",
+    "manifestFile": "lake-manifest.json",
+-   "inputRev": "v4.14.0",
++   "inputRev": "main",
+    "inherited": true,
+    "configFile": "lakefile.toml"},
+-  {"url": "https://github.com/leanprover-community/quote4",
++  {"url": "https://github.com/leanprover-community/import-graph",
+    "type": "git",
+    "subDir": null,
+    "scope": "leanprover-community",
+-   "rev": "303b23fbcea94ac4f96e590c1cad6618fd4f5f41",
+-   "name": "Qq",
++   "rev": "e285a7ade149c551c17a4b24f127e1ef782e4bb1",
++   "name": "importGraph",
+    "manifestFile": "lake-manifest.json",
+-   "inputRev": "master",
++   "inputRev": "main",
+    "inherited": true,
+-   "configFile": "lakefile.lean"},
+-  {"url": "https://github.com/leanprover-community/batteries",
++   "configFile": "lakefile.toml"},
++  {"url": "https://github.com/leanprover-community/LeanSearchClient",
+    "type": "git",
+    "subDir": null,
+    "scope": "leanprover-community",
+-   "rev": "8d6c853f11a5172efa0e96b9f2be1a83d861cdd9",
+-   "name": "batteries",
++   "rev": "2ba60fa2c384a94735454db11a2d523612eaabff",
++   "name": "LeanSearchClient",
+    "manifestFile": "lake-manifest.json",
+-   "inputRev": "v4.14.0",
++   "inputRev": "main",
+    "inherited": true,
+    "configFile": "lakefile.toml"},
+-  {"url": "https://github.com/leanprover/lean4-cli",
++  {"url": "https://github.com/leanprover-community/mathlib4",
+    "type": "git",
+    "subDir": null,
+-   "scope": "leanprover",
+-   "rev": "726b3c9ad13acca724d4651f14afc4804a7b0e4d",
+-   "name": "Cli",
++   "scope": "",
++   "rev": "809c3fb3b5c8f5d7dace56e200b426187516535a",
++   "name": "mathlib",
+    "manifestFile": "lake-manifest.json",
+-   "inputRev": "main",
+-   "inherited": true,
+-   "configFile": "lakefile.toml"}],
++   "inputRev": "v4.12.0",
++   "inherited": false,
++   "configFile": "lakefile.lean"}],
+  "name": "«repl-mathlib-tests»",
+  "lakeDir": ".lake"}
+diff --git a/test/Mathlib/lakefile.toml b/test/Mathlib/lakefile.toml
+index 6ff9631..f703b4d 100644
+--- a/test/Mathlib/lakefile.toml
++++ b/test/Mathlib/lakefile.toml
+@@ -1,11 +1,11 @@
+-name = "«repl-mathlib-tests»"
++name           = "«repl-mathlib-tests»"
+ defaultTargets = ["ReplMathlibTests"]
+ 
+ [[require]]
+ name = "mathlib"
+-git = "https://github.com/leanprover-community/mathlib4"
+-rev = "v4.14.0"
++git  = "https://github.com/leanprover-community/mathlib4"
++rev  = "v4.12.0"
+ 
+ [[lean_lib]]
+-name = "ReplMathlibTests"
++name  = "ReplMathlibTests"
+ globs = ["test.+"]
+diff --git a/test/Mathlib/lean-toolchain b/test/Mathlib/lean-toolchain
+index 401bc14..8998520 100644
+--- a/test/Mathlib/lean-toolchain
++++ b/test/Mathlib/lean-toolchain
+@@ -1 +1 @@
+-leanprover/lean4:v4.14.0
+\ No newline at end of file
++leanprover/lean4:v4.12.0
+diff --git a/test/all_tactics.expected.out b/test/all_tactics.expected.out
+index 6ec808c..5374db8 100644
+--- a/test/all_tactics.expected.out
++++ b/test/all_tactics.expected.out
+@@ -9,7 +9,7 @@
+    "tactic": "exact t",
+    "proofState": 1,
+    "pos": {"line": 1, "column": 32},
+-   "goals": "t : Nat\n⊢ Nat",
++   "goals": "t : Nat ⊢ Nat",
+    "endPos": {"line": 1, "column": 39}}],
+  "env": 0}
+ 
+diff --git a/test/calc.expected.out b/test/calc.expected.out
+index 94f6a9f..fde8fee 100644
+--- a/test/calc.expected.out
++++ b/test/calc.expected.out
+@@ -1,35 +1,22 @@
+ {"tactics":
+  [{"usedConstants":
+-   ["Trans.trans",
+-    "sorryAx",
+-    "instOfNatNat",
+-    "instTransEq",
+-    "Nat",
+-    "OfNat.ofNat",
+-    "Bool.false",
+-    "Eq"],
++   ["Trans.trans", "instOfNatNat", "instTransEq", "Nat", "OfNat.ofNat", "Eq"],
+    "tactic": "calc\n  3 = 4 := by sorry\n  4 = 5 := by sorry",
+    "proofState": 2,
+    "pos": {"line": 1, "column": 22},
+    "goals": "⊢ 3 = 5",
+    "endPos": {"line": 3, "column": 19}},
+-  {"usedConstants": [],
+-   "tactic": "\n  3 = 4 := by sorry\n  4 = 5 := by sorry",
+-   "proofState": 3,
+-   "pos": {"line": 2, "column": 2},
+-   "goals": "no goals",
+-   "endPos": {"line": 3, "column": 19}},
+   {"usedConstants":
+    ["sorryAx", "instOfNatNat", "Nat", "OfNat.ofNat", "Bool.false", "Eq"],
+    "tactic": "sorry",
+-   "proofState": 4,
++   "proofState": 3,
+    "pos": {"line": 2, "column": 14},
+    "goals": "⊢ 3 = 4",
+    "endPos": {"line": 2, "column": 19}},
+   {"usedConstants":
+    ["sorryAx", "instOfNatNat", "Nat", "OfNat.ofNat", "Bool.false", "Eq"],
+    "tactic": "sorry",
+-   "proofState": 5,
++   "proofState": 4,
+    "pos": {"line": 3, "column": 14},
+    "goals": "⊢ 4 = 5",
+    "endPos": {"line": 3, "column": 19}}],

--- a/versions/v4.13.0-rc1.diff
+++ b/versions/v4.13.0-rc1.diff
@@ -134,169 +134,26 @@ index a4b97c3..32702be 100644
    let infotree ← if jsonTrees.isEmpty then
      pure none
 diff --git a/lean-toolchain b/lean-toolchain
-index 1e70935..8998520 100644
+index 1e70935..a007978 100644
 --- a/lean-toolchain
 +++ b/lean-toolchain
 @@ -1 +1 @@
 -leanprover/lean4:v4.14.0
-+leanprover/lean4:v4.12.0
-diff --git a/test/Mathlib/lake-manifest.json b/test/Mathlib/lake-manifest.json
-index f312e5a..34f725d 100644
---- a/test/Mathlib/lake-manifest.json
-+++ b/test/Mathlib/lake-manifest.json
-@@ -1,95 +1,85 @@
- {"version": "1.1.0",
-  "packagesDir": ".lake/packages",
-  "packages":
-- [{"url": "https://github.com/leanprover-community/mathlib4",
--   "type": "git",
--   "subDir": null,
--   "scope": "",
--   "rev": "4bbdccd9c5f862bf90ff12f0a9e2c8be032b9a84",
--   "name": "mathlib",
--   "manifestFile": "lake-manifest.json",
--   "inputRev": "v4.14.0",
--   "inherited": false,
--   "configFile": "lakefile.lean"},
--  {"url": "https://github.com/leanprover-community/plausible",
-+ [{"url": "https://github.com/leanprover-community/batteries",
-    "type": "git",
-    "subDir": null,
-    "scope": "leanprover-community",
--   "rev": "42dc02bdbc5d0c2f395718462a76c3d87318f7fa",
--   "name": "plausible",
-+   "rev": "4756e0fc48acce0cc808df0ad149de5973240df6",
-+   "name": "batteries",
-    "manifestFile": "lake-manifest.json",
-    "inputRev": "main",
-    "inherited": true,
--   "configFile": "lakefile.toml"},
--  {"url": "https://github.com/leanprover-community/LeanSearchClient",
-+   "configFile": "lakefile.lean"},
-+  {"url": "https://github.com/leanprover-community/quote4",
-    "type": "git",
-    "subDir": null,
-    "scope": "leanprover-community",
--   "rev": "d7caecce0d0f003fd5e9cce9a61f1dd6ba83142b",
--   "name": "LeanSearchClient",
-+   "rev": "2c8ae451ce9ffc83554322b14437159c1a9703f9",
-+   "name": "Qq",
-    "manifestFile": "lake-manifest.json",
--   "inputRev": "main",
-+   "inputRev": "master",
-    "inherited": true,
--   "configFile": "lakefile.toml"},
--  {"url": "https://github.com/leanprover-community/import-graph",
-+   "configFile": "lakefile.lean"},
-+  {"url": "https://github.com/leanprover-community/aesop",
-    "type": "git",
-    "subDir": null,
-    "scope": "leanprover-community",
--   "rev": "519e509a28864af5bed98033dd33b95cf08e9aa7",
--   "name": "importGraph",
-+   "rev": "28fa80508edc97d96ed6342c9a771a67189e0baa",
-+   "name": "aesop",
-    "manifestFile": "lake-manifest.json",
--   "inputRev": "v4.14.0",
-+   "inputRev": "master",
-    "inherited": true,
-    "configFile": "lakefile.toml"},
-   {"url": "https://github.com/leanprover-community/ProofWidgets4",
-    "type": "git",
-    "subDir": null,
-    "scope": "leanprover-community",
--   "rev": "68280daef58803f68368eb2e53046dabcd270c9d",
-+   "rev": "eb08eee94098fe530ccd6d8751a86fe405473d4c",
-    "name": "proofwidgets",
-    "manifestFile": "lake-manifest.json",
--   "inputRev": "v0.0.47",
-+   "inputRev": "v0.0.42",
-    "inherited": true,
-    "configFile": "lakefile.lean"},
--  {"url": "https://github.com/leanprover-community/aesop",
-+  {"url": "https://github.com/leanprover/lean4-cli",
-    "type": "git",
-    "subDir": null,
--   "scope": "leanprover-community",
--   "rev": "5a0ec8588855265ade536f35bcdcf0fb24fd6030",
--   "name": "aesop",
-+   "scope": "",
-+   "rev": "2cf1030dc2ae6b3632c84a09350b675ef3e347d0",
-+   "name": "Cli",
-    "manifestFile": "lake-manifest.json",
--   "inputRev": "v4.14.0",
-+   "inputRev": "main",
-    "inherited": true,
-    "configFile": "lakefile.toml"},
--  {"url": "https://github.com/leanprover-community/quote4",
-+  {"url": "https://github.com/leanprover-community/import-graph",
-    "type": "git",
-    "subDir": null,
-    "scope": "leanprover-community",
--   "rev": "303b23fbcea94ac4f96e590c1cad6618fd4f5f41",
--   "name": "Qq",
-+   "rev": "e285a7ade149c551c17a4b24f127e1ef782e4bb1",
-+   "name": "importGraph",
-    "manifestFile": "lake-manifest.json",
--   "inputRev": "master",
-+   "inputRev": "main",
-    "inherited": true,
--   "configFile": "lakefile.lean"},
--  {"url": "https://github.com/leanprover-community/batteries",
-+   "configFile": "lakefile.toml"},
-+  {"url": "https://github.com/leanprover-community/LeanSearchClient",
-    "type": "git",
-    "subDir": null,
-    "scope": "leanprover-community",
--   "rev": "8d6c853f11a5172efa0e96b9f2be1a83d861cdd9",
--   "name": "batteries",
-+   "rev": "2ba60fa2c384a94735454db11a2d523612eaabff",
-+   "name": "LeanSearchClient",
-    "manifestFile": "lake-manifest.json",
--   "inputRev": "v4.14.0",
-+   "inputRev": "main",
-    "inherited": true,
-    "configFile": "lakefile.toml"},
--  {"url": "https://github.com/leanprover/lean4-cli",
-+  {"url": "https://github.com/leanprover-community/mathlib4",
-    "type": "git",
-    "subDir": null,
--   "scope": "leanprover",
--   "rev": "726b3c9ad13acca724d4651f14afc4804a7b0e4d",
--   "name": "Cli",
-+   "scope": "",
-+   "rev": "809c3fb3b5c8f5d7dace56e200b426187516535a",
-+   "name": "mathlib",
-    "manifestFile": "lake-manifest.json",
--   "inputRev": "main",
--   "inherited": true,
--   "configFile": "lakefile.toml"}],
-+   "inputRev": "v4.12.0",
-+   "inherited": false,
-+   "configFile": "lakefile.lean"}],
-  "name": "«repl-mathlib-tests»",
-  "lakeDir": ".lake"}
-diff --git a/test/Mathlib/lakefile.toml b/test/Mathlib/lakefile.toml
-index 6ff9631..daea648 100644
---- a/test/Mathlib/lakefile.toml
-+++ b/test/Mathlib/lakefile.toml
-@@ -4,7 +4,7 @@ defaultTargets = ["ReplMathlibTests"]
- [[require]]
- name = "mathlib"
- git = "https://github.com/leanprover-community/mathlib4"
--rev = "v4.14.0"
-+rev = "v4.12.0"
++leanprover/lean4:v4.13.0-rc1
+diff --git a/test.sh b/test.sh
+index 070ce3d..ed49bee 100755
+--- a/test.sh
++++ b/test.sh
+@@ -41,6 +41,6 @@ for infile in $IN_DIR/*.in; do
  
- [[lean_lib]]
- name = "ReplMathlibTests"
-diff --git a/test/Mathlib/lean-toolchain b/test/Mathlib/lean-toolchain
-index 401bc14..8998520 100644
---- a/test/Mathlib/lean-toolchain
-+++ b/test/Mathlib/lean-toolchain
-@@ -1 +1 @@
--leanprover/lean4:v4.14.0
-\ No newline at end of file
-+leanprover/lean4:v4.12.0
+ done
+ 
+-# Run the Mathlib tests
+-cp lean-toolchain test/Mathlib/
+-cd test/Mathlib/ && ./test.sh
++# Run the Mathlib tests - skipped as no Mathlib releases exist for v4.13.0-rc1
++# cp lean-toolchain test/Mathlib/
++# cd test/Mathlib/ && ./test.sh
 diff --git a/test/all_tactics.expected.out b/test/all_tactics.expected.out
 index 6ec808c..5374db8 100644
 --- a/test/all_tactics.expected.out

--- a/versions/v4.13.0-rc2.diff
+++ b/versions/v4.13.0-rc2.diff
@@ -134,169 +134,26 @@ index a4b97c3..32702be 100644
    let infotree ← if jsonTrees.isEmpty then
      pure none
 diff --git a/lean-toolchain b/lean-toolchain
-index 1e70935..8998520 100644
+index 1e70935..7c79e97 100644
 --- a/lean-toolchain
 +++ b/lean-toolchain
 @@ -1 +1 @@
 -leanprover/lean4:v4.14.0
-+leanprover/lean4:v4.12.0
-diff --git a/test/Mathlib/lake-manifest.json b/test/Mathlib/lake-manifest.json
-index f312e5a..34f725d 100644
---- a/test/Mathlib/lake-manifest.json
-+++ b/test/Mathlib/lake-manifest.json
-@@ -1,95 +1,85 @@
- {"version": "1.1.0",
-  "packagesDir": ".lake/packages",
-  "packages":
-- [{"url": "https://github.com/leanprover-community/mathlib4",
--   "type": "git",
--   "subDir": null,
--   "scope": "",
--   "rev": "4bbdccd9c5f862bf90ff12f0a9e2c8be032b9a84",
--   "name": "mathlib",
--   "manifestFile": "lake-manifest.json",
--   "inputRev": "v4.14.0",
--   "inherited": false,
--   "configFile": "lakefile.lean"},
--  {"url": "https://github.com/leanprover-community/plausible",
-+ [{"url": "https://github.com/leanprover-community/batteries",
-    "type": "git",
-    "subDir": null,
-    "scope": "leanprover-community",
--   "rev": "42dc02bdbc5d0c2f395718462a76c3d87318f7fa",
--   "name": "plausible",
-+   "rev": "4756e0fc48acce0cc808df0ad149de5973240df6",
-+   "name": "batteries",
-    "manifestFile": "lake-manifest.json",
-    "inputRev": "main",
-    "inherited": true,
--   "configFile": "lakefile.toml"},
--  {"url": "https://github.com/leanprover-community/LeanSearchClient",
-+   "configFile": "lakefile.lean"},
-+  {"url": "https://github.com/leanprover-community/quote4",
-    "type": "git",
-    "subDir": null,
-    "scope": "leanprover-community",
--   "rev": "d7caecce0d0f003fd5e9cce9a61f1dd6ba83142b",
--   "name": "LeanSearchClient",
-+   "rev": "2c8ae451ce9ffc83554322b14437159c1a9703f9",
-+   "name": "Qq",
-    "manifestFile": "lake-manifest.json",
--   "inputRev": "main",
-+   "inputRev": "master",
-    "inherited": true,
--   "configFile": "lakefile.toml"},
--  {"url": "https://github.com/leanprover-community/import-graph",
-+   "configFile": "lakefile.lean"},
-+  {"url": "https://github.com/leanprover-community/aesop",
-    "type": "git",
-    "subDir": null,
-    "scope": "leanprover-community",
--   "rev": "519e509a28864af5bed98033dd33b95cf08e9aa7",
--   "name": "importGraph",
-+   "rev": "28fa80508edc97d96ed6342c9a771a67189e0baa",
-+   "name": "aesop",
-    "manifestFile": "lake-manifest.json",
--   "inputRev": "v4.14.0",
-+   "inputRev": "master",
-    "inherited": true,
-    "configFile": "lakefile.toml"},
-   {"url": "https://github.com/leanprover-community/ProofWidgets4",
-    "type": "git",
-    "subDir": null,
-    "scope": "leanprover-community",
--   "rev": "68280daef58803f68368eb2e53046dabcd270c9d",
-+   "rev": "eb08eee94098fe530ccd6d8751a86fe405473d4c",
-    "name": "proofwidgets",
-    "manifestFile": "lake-manifest.json",
--   "inputRev": "v0.0.47",
-+   "inputRev": "v0.0.42",
-    "inherited": true,
-    "configFile": "lakefile.lean"},
--  {"url": "https://github.com/leanprover-community/aesop",
-+  {"url": "https://github.com/leanprover/lean4-cli",
-    "type": "git",
-    "subDir": null,
--   "scope": "leanprover-community",
--   "rev": "5a0ec8588855265ade536f35bcdcf0fb24fd6030",
--   "name": "aesop",
-+   "scope": "",
-+   "rev": "2cf1030dc2ae6b3632c84a09350b675ef3e347d0",
-+   "name": "Cli",
-    "manifestFile": "lake-manifest.json",
--   "inputRev": "v4.14.0",
-+   "inputRev": "main",
-    "inherited": true,
-    "configFile": "lakefile.toml"},
--  {"url": "https://github.com/leanprover-community/quote4",
-+  {"url": "https://github.com/leanprover-community/import-graph",
-    "type": "git",
-    "subDir": null,
-    "scope": "leanprover-community",
--   "rev": "303b23fbcea94ac4f96e590c1cad6618fd4f5f41",
--   "name": "Qq",
-+   "rev": "e285a7ade149c551c17a4b24f127e1ef782e4bb1",
-+   "name": "importGraph",
-    "manifestFile": "lake-manifest.json",
--   "inputRev": "master",
-+   "inputRev": "main",
-    "inherited": true,
--   "configFile": "lakefile.lean"},
--  {"url": "https://github.com/leanprover-community/batteries",
-+   "configFile": "lakefile.toml"},
-+  {"url": "https://github.com/leanprover-community/LeanSearchClient",
-    "type": "git",
-    "subDir": null,
-    "scope": "leanprover-community",
--   "rev": "8d6c853f11a5172efa0e96b9f2be1a83d861cdd9",
--   "name": "batteries",
-+   "rev": "2ba60fa2c384a94735454db11a2d523612eaabff",
-+   "name": "LeanSearchClient",
-    "manifestFile": "lake-manifest.json",
--   "inputRev": "v4.14.0",
-+   "inputRev": "main",
-    "inherited": true,
-    "configFile": "lakefile.toml"},
--  {"url": "https://github.com/leanprover/lean4-cli",
-+  {"url": "https://github.com/leanprover-community/mathlib4",
-    "type": "git",
-    "subDir": null,
--   "scope": "leanprover",
--   "rev": "726b3c9ad13acca724d4651f14afc4804a7b0e4d",
--   "name": "Cli",
-+   "scope": "",
-+   "rev": "809c3fb3b5c8f5d7dace56e200b426187516535a",
-+   "name": "mathlib",
-    "manifestFile": "lake-manifest.json",
--   "inputRev": "main",
--   "inherited": true,
--   "configFile": "lakefile.toml"}],
-+   "inputRev": "v4.12.0",
-+   "inherited": false,
-+   "configFile": "lakefile.lean"}],
-  "name": "«repl-mathlib-tests»",
-  "lakeDir": ".lake"}
-diff --git a/test/Mathlib/lakefile.toml b/test/Mathlib/lakefile.toml
-index 6ff9631..daea648 100644
---- a/test/Mathlib/lakefile.toml
-+++ b/test/Mathlib/lakefile.toml
-@@ -4,7 +4,7 @@ defaultTargets = ["ReplMathlibTests"]
- [[require]]
- name = "mathlib"
- git = "https://github.com/leanprover-community/mathlib4"
--rev = "v4.14.0"
-+rev = "v4.12.0"
++leanprover/lean4:v4.13.0-rc2
+diff --git a/test.sh b/test.sh
+index 070ce3d..f53c4c2 100755
+--- a/test.sh
++++ b/test.sh
+@@ -41,6 +41,6 @@ for infile in $IN_DIR/*.in; do
  
- [[lean_lib]]
- name = "ReplMathlibTests"
-diff --git a/test/Mathlib/lean-toolchain b/test/Mathlib/lean-toolchain
-index 401bc14..8998520 100644
---- a/test/Mathlib/lean-toolchain
-+++ b/test/Mathlib/lean-toolchain
-@@ -1 +1 @@
--leanprover/lean4:v4.14.0
-\ No newline at end of file
-+leanprover/lean4:v4.12.0
+ done
+ 
+-# Run the Mathlib tests
+-cp lean-toolchain test/Mathlib/
+-cd test/Mathlib/ && ./test.sh
++# Run the Mathlib tests - skipped as no Mathlib releases exist for v4.13.0-rc2
++# cp lean-toolchain test/Mathlib/
++# cd test/Mathlib/ && ./test.sh
 diff --git a/test/all_tactics.expected.out b/test/all_tactics.expected.out
 index 6ec808c..5374db8 100644
 --- a/test/all_tactics.expected.out

--- a/versions/v4.13.0-rc3.diff
+++ b/versions/v4.13.0-rc3.diff
@@ -134,169 +134,26 @@ index a4b97c3..32702be 100644
    let infotree ← if jsonTrees.isEmpty then
      pure none
 diff --git a/lean-toolchain b/lean-toolchain
-index 1e70935..8998520 100644
+index 1e70935..eff86fd 100644
 --- a/lean-toolchain
 +++ b/lean-toolchain
 @@ -1 +1 @@
 -leanprover/lean4:v4.14.0
-+leanprover/lean4:v4.12.0
-diff --git a/test/Mathlib/lake-manifest.json b/test/Mathlib/lake-manifest.json
-index f312e5a..34f725d 100644
---- a/test/Mathlib/lake-manifest.json
-+++ b/test/Mathlib/lake-manifest.json
-@@ -1,95 +1,85 @@
- {"version": "1.1.0",
-  "packagesDir": ".lake/packages",
-  "packages":
-- [{"url": "https://github.com/leanprover-community/mathlib4",
--   "type": "git",
--   "subDir": null,
--   "scope": "",
--   "rev": "4bbdccd9c5f862bf90ff12f0a9e2c8be032b9a84",
--   "name": "mathlib",
--   "manifestFile": "lake-manifest.json",
--   "inputRev": "v4.14.0",
--   "inherited": false,
--   "configFile": "lakefile.lean"},
--  {"url": "https://github.com/leanprover-community/plausible",
-+ [{"url": "https://github.com/leanprover-community/batteries",
-    "type": "git",
-    "subDir": null,
-    "scope": "leanprover-community",
--   "rev": "42dc02bdbc5d0c2f395718462a76c3d87318f7fa",
--   "name": "plausible",
-+   "rev": "4756e0fc48acce0cc808df0ad149de5973240df6",
-+   "name": "batteries",
-    "manifestFile": "lake-manifest.json",
-    "inputRev": "main",
-    "inherited": true,
--   "configFile": "lakefile.toml"},
--  {"url": "https://github.com/leanprover-community/LeanSearchClient",
-+   "configFile": "lakefile.lean"},
-+  {"url": "https://github.com/leanprover-community/quote4",
-    "type": "git",
-    "subDir": null,
-    "scope": "leanprover-community",
--   "rev": "d7caecce0d0f003fd5e9cce9a61f1dd6ba83142b",
--   "name": "LeanSearchClient",
-+   "rev": "2c8ae451ce9ffc83554322b14437159c1a9703f9",
-+   "name": "Qq",
-    "manifestFile": "lake-manifest.json",
--   "inputRev": "main",
-+   "inputRev": "master",
-    "inherited": true,
--   "configFile": "lakefile.toml"},
--  {"url": "https://github.com/leanprover-community/import-graph",
-+   "configFile": "lakefile.lean"},
-+  {"url": "https://github.com/leanprover-community/aesop",
-    "type": "git",
-    "subDir": null,
-    "scope": "leanprover-community",
--   "rev": "519e509a28864af5bed98033dd33b95cf08e9aa7",
--   "name": "importGraph",
-+   "rev": "28fa80508edc97d96ed6342c9a771a67189e0baa",
-+   "name": "aesop",
-    "manifestFile": "lake-manifest.json",
--   "inputRev": "v4.14.0",
-+   "inputRev": "master",
-    "inherited": true,
-    "configFile": "lakefile.toml"},
-   {"url": "https://github.com/leanprover-community/ProofWidgets4",
-    "type": "git",
-    "subDir": null,
-    "scope": "leanprover-community",
--   "rev": "68280daef58803f68368eb2e53046dabcd270c9d",
-+   "rev": "eb08eee94098fe530ccd6d8751a86fe405473d4c",
-    "name": "proofwidgets",
-    "manifestFile": "lake-manifest.json",
--   "inputRev": "v0.0.47",
-+   "inputRev": "v0.0.42",
-    "inherited": true,
-    "configFile": "lakefile.lean"},
--  {"url": "https://github.com/leanprover-community/aesop",
-+  {"url": "https://github.com/leanprover/lean4-cli",
-    "type": "git",
-    "subDir": null,
--   "scope": "leanprover-community",
--   "rev": "5a0ec8588855265ade536f35bcdcf0fb24fd6030",
--   "name": "aesop",
-+   "scope": "",
-+   "rev": "2cf1030dc2ae6b3632c84a09350b675ef3e347d0",
-+   "name": "Cli",
-    "manifestFile": "lake-manifest.json",
--   "inputRev": "v4.14.0",
-+   "inputRev": "main",
-    "inherited": true,
-    "configFile": "lakefile.toml"},
--  {"url": "https://github.com/leanprover-community/quote4",
-+  {"url": "https://github.com/leanprover-community/import-graph",
-    "type": "git",
-    "subDir": null,
-    "scope": "leanprover-community",
--   "rev": "303b23fbcea94ac4f96e590c1cad6618fd4f5f41",
--   "name": "Qq",
-+   "rev": "e285a7ade149c551c17a4b24f127e1ef782e4bb1",
-+   "name": "importGraph",
-    "manifestFile": "lake-manifest.json",
--   "inputRev": "master",
-+   "inputRev": "main",
-    "inherited": true,
--   "configFile": "lakefile.lean"},
--  {"url": "https://github.com/leanprover-community/batteries",
-+   "configFile": "lakefile.toml"},
-+  {"url": "https://github.com/leanprover-community/LeanSearchClient",
-    "type": "git",
-    "subDir": null,
-    "scope": "leanprover-community",
--   "rev": "8d6c853f11a5172efa0e96b9f2be1a83d861cdd9",
--   "name": "batteries",
-+   "rev": "2ba60fa2c384a94735454db11a2d523612eaabff",
-+   "name": "LeanSearchClient",
-    "manifestFile": "lake-manifest.json",
--   "inputRev": "v4.14.0",
-+   "inputRev": "main",
-    "inherited": true,
-    "configFile": "lakefile.toml"},
--  {"url": "https://github.com/leanprover/lean4-cli",
-+  {"url": "https://github.com/leanprover-community/mathlib4",
-    "type": "git",
-    "subDir": null,
--   "scope": "leanprover",
--   "rev": "726b3c9ad13acca724d4651f14afc4804a7b0e4d",
--   "name": "Cli",
-+   "scope": "",
-+   "rev": "809c3fb3b5c8f5d7dace56e200b426187516535a",
-+   "name": "mathlib",
-    "manifestFile": "lake-manifest.json",
--   "inputRev": "main",
--   "inherited": true,
--   "configFile": "lakefile.toml"}],
-+   "inputRev": "v4.12.0",
-+   "inherited": false,
-+   "configFile": "lakefile.lean"}],
-  "name": "«repl-mathlib-tests»",
-  "lakeDir": ".lake"}
-diff --git a/test/Mathlib/lakefile.toml b/test/Mathlib/lakefile.toml
-index 6ff9631..daea648 100644
---- a/test/Mathlib/lakefile.toml
-+++ b/test/Mathlib/lakefile.toml
-@@ -4,7 +4,7 @@ defaultTargets = ["ReplMathlibTests"]
- [[require]]
- name = "mathlib"
- git = "https://github.com/leanprover-community/mathlib4"
--rev = "v4.14.0"
-+rev = "v4.12.0"
++leanprover/lean4:v4.13.0-rc3
+diff --git a/test.sh b/test.sh
+index 070ce3d..282cd75 100755
+--- a/test.sh
++++ b/test.sh
+@@ -41,6 +41,6 @@ for infile in $IN_DIR/*.in; do
  
- [[lean_lib]]
- name = "ReplMathlibTests"
-diff --git a/test/Mathlib/lean-toolchain b/test/Mathlib/lean-toolchain
-index 401bc14..8998520 100644
---- a/test/Mathlib/lean-toolchain
-+++ b/test/Mathlib/lean-toolchain
-@@ -1 +1 @@
--leanprover/lean4:v4.14.0
-\ No newline at end of file
-+leanprover/lean4:v4.12.0
+ done
+ 
+-# Run the Mathlib tests
+-cp lean-toolchain test/Mathlib/
+-cd test/Mathlib/ && ./test.sh
++# Run the Mathlib tests - skipped as no Mathlib releases exist for v4.13.0-rc3
++# cp lean-toolchain test/Mathlib/
++# cd test/Mathlib/ && ./test.sh
 diff --git a/test/all_tactics.expected.out b/test/all_tactics.expected.out
 index 6ec808c..5374db8 100644
 --- a/test/all_tactics.expected.out

--- a/versions/v4.13.0-rc4.diff
+++ b/versions/v4.13.0-rc4.diff
@@ -134,169 +134,26 @@ index a4b97c3..32702be 100644
    let infotree ← if jsonTrees.isEmpty then
      pure none
 diff --git a/lean-toolchain b/lean-toolchain
-index 1e70935..8998520 100644
+index 1e70935..a254364 100644
 --- a/lean-toolchain
 +++ b/lean-toolchain
 @@ -1 +1 @@
 -leanprover/lean4:v4.14.0
-+leanprover/lean4:v4.12.0
-diff --git a/test/Mathlib/lake-manifest.json b/test/Mathlib/lake-manifest.json
-index f312e5a..34f725d 100644
---- a/test/Mathlib/lake-manifest.json
-+++ b/test/Mathlib/lake-manifest.json
-@@ -1,95 +1,85 @@
- {"version": "1.1.0",
-  "packagesDir": ".lake/packages",
-  "packages":
-- [{"url": "https://github.com/leanprover-community/mathlib4",
--   "type": "git",
--   "subDir": null,
--   "scope": "",
--   "rev": "4bbdccd9c5f862bf90ff12f0a9e2c8be032b9a84",
--   "name": "mathlib",
--   "manifestFile": "lake-manifest.json",
--   "inputRev": "v4.14.0",
--   "inherited": false,
--   "configFile": "lakefile.lean"},
--  {"url": "https://github.com/leanprover-community/plausible",
-+ [{"url": "https://github.com/leanprover-community/batteries",
-    "type": "git",
-    "subDir": null,
-    "scope": "leanprover-community",
--   "rev": "42dc02bdbc5d0c2f395718462a76c3d87318f7fa",
--   "name": "plausible",
-+   "rev": "4756e0fc48acce0cc808df0ad149de5973240df6",
-+   "name": "batteries",
-    "manifestFile": "lake-manifest.json",
-    "inputRev": "main",
-    "inherited": true,
--   "configFile": "lakefile.toml"},
--  {"url": "https://github.com/leanprover-community/LeanSearchClient",
-+   "configFile": "lakefile.lean"},
-+  {"url": "https://github.com/leanprover-community/quote4",
-    "type": "git",
-    "subDir": null,
-    "scope": "leanprover-community",
--   "rev": "d7caecce0d0f003fd5e9cce9a61f1dd6ba83142b",
--   "name": "LeanSearchClient",
-+   "rev": "2c8ae451ce9ffc83554322b14437159c1a9703f9",
-+   "name": "Qq",
-    "manifestFile": "lake-manifest.json",
--   "inputRev": "main",
-+   "inputRev": "master",
-    "inherited": true,
--   "configFile": "lakefile.toml"},
--  {"url": "https://github.com/leanprover-community/import-graph",
-+   "configFile": "lakefile.lean"},
-+  {"url": "https://github.com/leanprover-community/aesop",
-    "type": "git",
-    "subDir": null,
-    "scope": "leanprover-community",
--   "rev": "519e509a28864af5bed98033dd33b95cf08e9aa7",
--   "name": "importGraph",
-+   "rev": "28fa80508edc97d96ed6342c9a771a67189e0baa",
-+   "name": "aesop",
-    "manifestFile": "lake-manifest.json",
--   "inputRev": "v4.14.0",
-+   "inputRev": "master",
-    "inherited": true,
-    "configFile": "lakefile.toml"},
-   {"url": "https://github.com/leanprover-community/ProofWidgets4",
-    "type": "git",
-    "subDir": null,
-    "scope": "leanprover-community",
--   "rev": "68280daef58803f68368eb2e53046dabcd270c9d",
-+   "rev": "eb08eee94098fe530ccd6d8751a86fe405473d4c",
-    "name": "proofwidgets",
-    "manifestFile": "lake-manifest.json",
--   "inputRev": "v0.0.47",
-+   "inputRev": "v0.0.42",
-    "inherited": true,
-    "configFile": "lakefile.lean"},
--  {"url": "https://github.com/leanprover-community/aesop",
-+  {"url": "https://github.com/leanprover/lean4-cli",
-    "type": "git",
-    "subDir": null,
--   "scope": "leanprover-community",
--   "rev": "5a0ec8588855265ade536f35bcdcf0fb24fd6030",
--   "name": "aesop",
-+   "scope": "",
-+   "rev": "2cf1030dc2ae6b3632c84a09350b675ef3e347d0",
-+   "name": "Cli",
-    "manifestFile": "lake-manifest.json",
--   "inputRev": "v4.14.0",
-+   "inputRev": "main",
-    "inherited": true,
-    "configFile": "lakefile.toml"},
--  {"url": "https://github.com/leanprover-community/quote4",
-+  {"url": "https://github.com/leanprover-community/import-graph",
-    "type": "git",
-    "subDir": null,
-    "scope": "leanprover-community",
--   "rev": "303b23fbcea94ac4f96e590c1cad6618fd4f5f41",
--   "name": "Qq",
-+   "rev": "e285a7ade149c551c17a4b24f127e1ef782e4bb1",
-+   "name": "importGraph",
-    "manifestFile": "lake-manifest.json",
--   "inputRev": "master",
-+   "inputRev": "main",
-    "inherited": true,
--   "configFile": "lakefile.lean"},
--  {"url": "https://github.com/leanprover-community/batteries",
-+   "configFile": "lakefile.toml"},
-+  {"url": "https://github.com/leanprover-community/LeanSearchClient",
-    "type": "git",
-    "subDir": null,
-    "scope": "leanprover-community",
--   "rev": "8d6c853f11a5172efa0e96b9f2be1a83d861cdd9",
--   "name": "batteries",
-+   "rev": "2ba60fa2c384a94735454db11a2d523612eaabff",
-+   "name": "LeanSearchClient",
-    "manifestFile": "lake-manifest.json",
--   "inputRev": "v4.14.0",
-+   "inputRev": "main",
-    "inherited": true,
-    "configFile": "lakefile.toml"},
--  {"url": "https://github.com/leanprover/lean4-cli",
-+  {"url": "https://github.com/leanprover-community/mathlib4",
-    "type": "git",
-    "subDir": null,
--   "scope": "leanprover",
--   "rev": "726b3c9ad13acca724d4651f14afc4804a7b0e4d",
--   "name": "Cli",
-+   "scope": "",
-+   "rev": "809c3fb3b5c8f5d7dace56e200b426187516535a",
-+   "name": "mathlib",
-    "manifestFile": "lake-manifest.json",
--   "inputRev": "main",
--   "inherited": true,
--   "configFile": "lakefile.toml"}],
-+   "inputRev": "v4.12.0",
-+   "inherited": false,
-+   "configFile": "lakefile.lean"}],
-  "name": "«repl-mathlib-tests»",
-  "lakeDir": ".lake"}
-diff --git a/test/Mathlib/lakefile.toml b/test/Mathlib/lakefile.toml
-index 6ff9631..daea648 100644
---- a/test/Mathlib/lakefile.toml
-+++ b/test/Mathlib/lakefile.toml
-@@ -4,7 +4,7 @@ defaultTargets = ["ReplMathlibTests"]
- [[require]]
- name = "mathlib"
- git = "https://github.com/leanprover-community/mathlib4"
--rev = "v4.14.0"
-+rev = "v4.12.0"
++leanprover/lean4:v4.13.0-rc4
+diff --git a/test.sh b/test.sh
+index 070ce3d..844d52c 100755
+--- a/test.sh
++++ b/test.sh
+@@ -41,6 +41,6 @@ for infile in $IN_DIR/*.in; do
  
- [[lean_lib]]
- name = "ReplMathlibTests"
-diff --git a/test/Mathlib/lean-toolchain b/test/Mathlib/lean-toolchain
-index 401bc14..8998520 100644
---- a/test/Mathlib/lean-toolchain
-+++ b/test/Mathlib/lean-toolchain
-@@ -1 +1 @@
--leanprover/lean4:v4.14.0
-\ No newline at end of file
-+leanprover/lean4:v4.12.0
+ done
+ 
+-# Run the Mathlib tests
+-cp lean-toolchain test/Mathlib/
+-cd test/Mathlib/ && ./test.sh
++# Run the Mathlib tests - skipped as no Mathlib releases exist for v4.13.0-rc4
++# cp lean-toolchain test/Mathlib/
++# cd test/Mathlib/ && ./test.sh
 diff --git a/test/all_tactics.expected.out b/test/all_tactics.expected.out
 index 6ec808c..5374db8 100644
 --- a/test/all_tactics.expected.out

--- a/versions/v4.13.0.diff
+++ b/versions/v4.13.0.diff
@@ -1,19 +1,3 @@
-diff --git a/REPL/Frontend.lean b/REPL/Frontend.lean
-index 9cc0914..a2bb150 100644
---- a/REPL/Frontend.lean
-+++ b/REPL/Frontend.lean
-@@ -20,7 +20,10 @@ def processCommandsWithInfoTrees
-     (commandState : Command.State) : IO (Command.State × List Message × List InfoTree) := do
-   let commandState := { commandState with infoState.enabled := true }
-   let s ← IO.processCommands inputCtx parserState commandState <&> Frontend.State.commandState
--  pure (s, s.messages.toList, s.infoState.trees.toList)
-+  let msgs := s.messages.toList.drop commandState.messages.toList.length
-+  let trees := s.infoState.trees.toList.drop commandState.infoState.trees.size
-+
-+  pure (s, msgs, trees)
- 
- /--
- Process some text input, with or without an existing command state.
 diff --git a/REPL/JSON.lean b/REPL/JSON.lean
 index d5c5ba2..b63c5ea 100644
 --- a/REPL/JSON.lean
@@ -45,18 +29,6 @@ index d5c5ba2..b63c5ea 100644
      [("proofState", r.proofState)],
      [("goals", toJson r.goals)],
      Json.nonemptyList "messages" r.messages,
-diff --git a/REPL/Lean/Environment.lean b/REPL/Lean/Environment.lean
-index 0b4be3c..61d4e76 100644
---- a/REPL/Lean/Environment.lean
-+++ b/REPL/Lean/Environment.lean
-@@ -26,6 +26,6 @@ and then replace the new constants.
- def unpickle (path : FilePath) : IO (Environment × CompactedRegion) := unsafe do
-   let ((imports, map₂), region) ← _root_.unpickle (Array Import × PHashMap Name ConstantInfo) path
-   let env ← importModules imports {} 0
--  return (← env.replay (Std.HashMap.ofList map₂.toList), region)
-+  return (← env.replay (HashMap.ofList map₂.toList), region)
- 
- end Lean.Environment
 diff --git a/REPL/Lean/InfoTree.lean b/REPL/Lean/InfoTree.lean
 index 7abf0b8..d3b28c1 100644
 --- a/REPL/Lean/InfoTree.lean
@@ -104,7 +76,7 @@ index 7abf0b8..d3b28c1 100644
  
  
 diff --git a/REPL/Main.lean b/REPL/Main.lean
-index a4b97c3..8211b8c 100644
+index a4b97c3..32702be 100644
 --- a/REPL/Main.lean
 +++ b/REPL/Main.lean
 @@ -95,7 +95,7 @@ def recordProofSnapshot (proofState : ProofSnapshot) : M m Nat := do
@@ -125,7 +97,30 @@ index a4b97c3..8211b8c 100644
      fun ⟨ctx, stx, goals, pos, endPos, ns⟩ => do
        let proofState := some (← ProofSnapshot.create ctx none none goals)
        let goals := s!"{(← ctx.ppGoals goals)}".trim
-@@ -218,9 +218,9 @@ def runCommand (s : Command) : M IO (CommandResponse ⊕ Error) := do
+@@ -184,6 +184,14 @@ def unpickleProofSnapshot (n : UnpickleProofState) : M IO (ProofStepResponse ⊕
+   let (proofState, _) ← ProofSnapshot.unpickle n.unpickleProofStateFrom cmdSnapshot?
+   Sum.inl <$> createProofStepReponse proofState
+ 
++partial def filterRootTactics (tree : InfoTree) : Bool :=
++  match tree with
++  | InfoTree.hole _     => true
++  | InfoTree.context _ t => filterRootTactics t
++  | InfoTree.node i _   => match i with
++      | .ofTacticInfo _ => false
++      | _ => true
++
+ /--
+ Run a command, returning the id of the new environment, and any messages and sorries.
+ -/
+@@ -201,6 +209,7 @@ def runCommand (s : Command) : M IO (CommandResponse ⊕ Error) := do
+   catch ex =>
+     return .inr ⟨ex.toString⟩
+   let messages ← messages.mapM fun m => Message.of m
++  let trees := trees.filter filterRootTactics
+   -- For debugging purposes, sometimes we print out the trees here:
+   -- trees.forM fun t => do IO.println (← t.format)
+   let sorries ← sorries trees (initialCmdState?.map (·.env))
+@@ -218,9 +227,9 @@ def runCommand (s : Command) : M IO (CommandResponse ⊕ Error) := do
    let env ← recordCommandSnapshot cmdSnapshot
    let jsonTrees := match s.infotree with
    | some "full" => trees
@@ -138,43 +133,18 @@ index a4b97c3..8211b8c 100644
    | _ => []
    let infotree ← if jsonTrees.isEmpty then
      pure none
-diff --git a/REPL/Snapshots.lean b/REPL/Snapshots.lean
-index 1114c24..7462141 100644
---- a/REPL/Snapshots.lean
-+++ b/REPL/Snapshots.lean
-@@ -83,7 +83,7 @@ def unpickle (path : FilePath) : IO (CommandSnapshot × CompactedRegion) := unsa
-   let ((imports, map₂, cmdState, cmdContext), region) ←
-     _root_.unpickle (Array Import × PHashMap Name ConstantInfo × CompactableCommandSnapshot ×
-       Command.Context) path
--  let env ← (← importModules imports {} 0).replay (Std.HashMap.ofList map₂.toList)
-+  let env ← (← importModules imports {} 0).replay (HashMap.ofList map₂.toList)
-   let p' : CommandSnapshot :=
-   { cmdState := { cmdState with env }
-     cmdContext }
-@@ -284,9 +284,9 @@ def unpickle (path : FilePath) (cmd? : Option CommandSnapshot) :
-   let env ← match cmd? with
-   | none =>
-     enableInitializersExecution
--    (← importModules imports {} 0).replay (Std.HashMap.ofList map₂.toList)
-+    (← importModules imports {} 0).replay (HashMap.ofList map₂.toList)
-   | some cmd =>
--    cmd.cmdState.env.replay (Std.HashMap.ofList map₂.toList)
-+    cmd.cmdState.env.replay (HashMap.ofList map₂.toList)
-   let p' : ProofSnapshot :=
-   { coreState := { coreState with env }
-     coreContext
 diff --git a/lean-toolchain b/lean-toolchain
-index 1e70935..5a9c76d 100644
+index 1e70935..4f86f95 100644
 --- a/lean-toolchain
 +++ b/lean-toolchain
 @@ -1 +1 @@
 -leanprover/lean4:v4.14.0
-+leanprover/lean4:v4.11.0
++leanprover/lean4:v4.13.0
 diff --git a/test/Mathlib/lake-manifest.json b/test/Mathlib/lake-manifest.json
-index f312e5a..818bb5a 100644
+index f312e5a..bfca34d 100644
 --- a/test/Mathlib/lake-manifest.json
 +++ b/test/Mathlib/lake-manifest.json
-@@ -1,95 +1,75 @@
+@@ -1,95 +1,95 @@
  {"version": "1.1.0",
   "packagesDir": ".lake/packages",
   "packages":
@@ -195,21 +165,20 @@ index f312e5a..818bb5a 100644
     "scope": "leanprover-community",
 -   "rev": "42dc02bdbc5d0c2f395718462a76c3d87318f7fa",
 -   "name": "plausible",
-+   "rev": "9c6c2d647e57b2b7a0b42dd8080c698bd33a1b6f",
++   "rev": "31a10a332858d6981dbcf55d54ee51680dd75f18",
 +   "name": "batteries",
     "manifestFile": "lake-manifest.json",
     "inputRev": "main",
     "inherited": true,
--   "configFile": "lakefile.toml"},
+    "configFile": "lakefile.toml"},
 -  {"url": "https://github.com/leanprover-community/LeanSearchClient",
-+   "configFile": "lakefile.lean"},
 +  {"url": "https://github.com/leanprover-community/quote4",
     "type": "git",
     "subDir": null,
     "scope": "leanprover-community",
 -   "rev": "d7caecce0d0f003fd5e9cce9a61f1dd6ba83142b",
 -   "name": "LeanSearchClient",
-+   "rev": "9d0bdd07bdfe53383567509348b1fe917fc08de4",
++   "rev": "1357f4f49450abb9dfd4783e38219f4ce84f9785",
 +   "name": "Qq",
     "manifestFile": "lake-manifest.json",
 -   "inputRev": "main",
@@ -224,7 +193,7 @@ index f312e5a..818bb5a 100644
     "scope": "leanprover-community",
 -   "rev": "519e509a28864af5bed98033dd33b95cf08e9aa7",
 -   "name": "importGraph",
-+   "rev": "deb279eb7be16848d0bc8387f80d6e41bcdbe738",
++   "rev": "5f934891e11d70a1b86e302fdf9cecfc21e8de46",
 +   "name": "aesop",
     "manifestFile": "lake-manifest.json",
 -   "inputRev": "v4.14.0",
@@ -236,11 +205,11 @@ index f312e5a..818bb5a 100644
     "subDir": null,
     "scope": "leanprover-community",
 -   "rev": "68280daef58803f68368eb2e53046dabcd270c9d",
-+   "rev": "a96aee5245720f588876021b6a0aa73efee49c76",
++   "rev": "23268f52d3505955de3c26a42032702c25cfcbf8",
     "name": "proofwidgets",
     "manifestFile": "lake-manifest.json",
 -   "inputRev": "v0.0.47",
-+   "inputRev": "v0.0.41",
++   "inputRev": "v0.0.44",
     "inherited": true,
     "configFile": "lakefile.lean"},
 -  {"url": "https://github.com/leanprover-community/aesop",
@@ -250,7 +219,7 @@ index f312e5a..818bb5a 100644
 -   "scope": "leanprover-community",
 -   "rev": "5a0ec8588855265ade536f35bcdcf0fb24fd6030",
 -   "name": "aesop",
-+   "scope": "",
++   "scope": "leanprover",
 +   "rev": "2cf1030dc2ae6b3632c84a09350b675ef3e347d0",
 +   "name": "Cli",
     "manifestFile": "lake-manifest.json",
@@ -259,50 +228,63 @@ index f312e5a..818bb5a 100644
     "inherited": true,
     "configFile": "lakefile.toml"},
 -  {"url": "https://github.com/leanprover-community/quote4",
--   "type": "git",
--   "subDir": null,
--   "scope": "leanprover-community",
++  {"url": "https://github.com/leanprover-community/import-graph",
+    "type": "git",
+    "subDir": null,
+    "scope": "leanprover-community",
 -   "rev": "303b23fbcea94ac4f96e590c1cad6618fd4f5f41",
 -   "name": "Qq",
--   "manifestFile": "lake-manifest.json",
++   "rev": "984d7ee170b75d6b03c0903e0b750ee2c6d1e3fb",
++   "name": "importGraph",
+    "manifestFile": "lake-manifest.json",
 -   "inputRev": "master",
--   "inherited": true,
++   "inputRev": "main",
+    "inherited": true,
 -   "configFile": "lakefile.lean"},
 -  {"url": "https://github.com/leanprover-community/batteries",
-+  {"url": "https://github.com/leanprover-community/import-graph",
++   "configFile": "lakefile.toml"},
++  {"url": "https://github.com/leanprover-community/LeanSearchClient",
     "type": "git",
     "subDir": null,
     "scope": "leanprover-community",
 -   "rev": "8d6c853f11a5172efa0e96b9f2be1a83d861cdd9",
 -   "name": "batteries",
-+   "rev": "1ef0b288623337cb37edd1222b9c26b4b77c6620",
-+   "name": "importGraph",
++   "rev": "7bedaed1ef024add1e171cc17706b012a9a37802",
++   "name": "LeanSearchClient",
     "manifestFile": "lake-manifest.json",
 -   "inputRev": "v4.14.0",
 +   "inputRev": "main",
     "inherited": true,
     "configFile": "lakefile.toml"},
 -  {"url": "https://github.com/leanprover/lean4-cli",
-+  {"url": "https://github.com/leanprover-community/mathlib4",
++  {"url": "https://github.com/leanprover-community/plausible",
     "type": "git",
     "subDir": null,
 -   "scope": "leanprover",
 -   "rev": "726b3c9ad13acca724d4651f14afc4804a7b0e4d",
 -   "name": "Cli",
-+   "scope": "",
-+   "rev": "8edf04f0977c3183d3b633792e03fd570be1777f",
-+   "name": "mathlib",
++   "scope": "leanprover-community",
++   "rev": "d212dd74414e997653cd3484921f4159c955ccca",
++   "name": "plausible",
     "manifestFile": "lake-manifest.json",
--   "inputRev": "main",
--   "inherited": true,
+    "inputRev": "main",
+    "inherited": true,
 -   "configFile": "lakefile.toml"}],
-+   "inputRev": "master",
++   "configFile": "lakefile.toml"},
++  {"url": "https://github.com/leanprover-community/mathlib4",
++   "type": "git",
++   "subDir": null,
++   "scope": "",
++   "rev": "d7317655e2826dc1f1de9a0c138db2775c4bb841",
++   "name": "mathlib",
++   "manifestFile": "lake-manifest.json",
++   "inputRev": "v4.13.0",
 +   "inherited": false,
 +   "configFile": "lakefile.lean"}],
   "name": "«repl-mathlib-tests»",
   "lakeDir": ".lake"}
 diff --git a/test/Mathlib/lakefile.toml b/test/Mathlib/lakefile.toml
-index 6ff9631..1546899 100644
+index 6ff9631..c7e1ebf 100644
 --- a/test/Mathlib/lakefile.toml
 +++ b/test/Mathlib/lakefile.toml
 @@ -4,7 +4,7 @@ defaultTargets = ["ReplMathlibTests"]
@@ -310,18 +292,18 @@ index 6ff9631..1546899 100644
  name = "mathlib"
  git = "https://github.com/leanprover-community/mathlib4"
 -rev = "v4.14.0"
-+rev = "master"
++rev = "v4.13.0"
  
  [[lean_lib]]
  name = "ReplMathlibTests"
 diff --git a/test/Mathlib/lean-toolchain b/test/Mathlib/lean-toolchain
-index 401bc14..5a9c76d 100644
+index 401bc14..4f86f95 100644
 --- a/test/Mathlib/lean-toolchain
 +++ b/test/Mathlib/lean-toolchain
 @@ -1 +1 @@
 -leanprover/lean4:v4.14.0
 \ No newline at end of file
-+leanprover/lean4:v4.11.0
++leanprover/lean4:v4.13.0
 diff --git a/test/all_tactics.expected.out b/test/all_tactics.expected.out
 index 6ec808c..5374db8 100644
 --- a/test/all_tactics.expected.out

--- a/versions/v4.14.0-rc1.diff
+++ b/versions/v4.14.0-rc1.diff
@@ -158,7 +158,7 @@ index 6ff9631..0e662ff 100644
  git = "https://github.com/leanprover-community/mathlib4"
 -rev = "v4.14.0"
 +rev = "v4.14.0-rc1"
- 
+
  [[lean_lib]]
  name = "ReplMathlibTests"
 diff --git a/test/Mathlib/lean-toolchain b/test/Mathlib/lean-toolchain
@@ -169,15 +169,3 @@ index 401bc14..0bef727 100644
 -leanprover/lean4:v4.14.0
 \ No newline at end of file
 +leanprover/lean4:v4.14.0-rc1
-diff --git a/versions/v4.14.0-rc1.diff b/versions/v4.14.0-rc1.diff
-index fff1539..3ba7b47 100644
---- a/versions/v4.14.0-rc1.diff
-+++ b/versions/v4.14.0-rc1.diff
-@@ -1,7 +0,0 @@
--diff --git a/lean-toolchain b/lean-toolchain
--index 1e70935..0bef727 100644
----- a/lean-toolchain
--+++ b/lean-toolchain
--@@ -1 +1 @@
---leanprover/lean4:v4.14.0
--+leanprover/lean4:v4.14.0-rc1

--- a/versions/v4.14.0-rc1.diff
+++ b/versions/v4.14.0-rc1.diff
@@ -1,0 +1,7 @@
+diff --git a/lean-toolchain b/lean-toolchain
+index 1e70935..0bef727 100644
+--- a/lean-toolchain
++++ b/lean-toolchain
+@@ -1 +1 @@
+-leanprover/lean4:v4.14.0
++leanprover/lean4:v4.14.0-rc1

--- a/versions/v4.14.0-rc1.diff
+++ b/versions/v4.14.0-rc1.diff
@@ -5,3 +5,179 @@ index 1e70935..0bef727 100644
 @@ -1 +1 @@
 -leanprover/lean4:v4.14.0
 +leanprover/lean4:v4.14.0-rc1
+diff --git a/test/Mathlib/lake-manifest.json b/test/Mathlib/lake-manifest.json
+index f312e5a..b5b36c2 100644
+--- a/test/Mathlib/lake-manifest.json
++++ b/test/Mathlib/lake-manifest.json
+@@ -1,95 +1,95 @@
+ {"version": "1.1.0",
+  "packagesDir": ".lake/packages",
+  "packages":
+- [{"url": "https://github.com/leanprover-community/mathlib4",
+-   "type": "git",
+-   "subDir": null,
+-   "scope": "",
+-   "rev": "4bbdccd9c5f862bf90ff12f0a9e2c8be032b9a84",
+-   "name": "mathlib",
+-   "manifestFile": "lake-manifest.json",
+-   "inputRev": "v4.14.0",
+-   "inherited": false,
+-   "configFile": "lakefile.lean"},
+-  {"url": "https://github.com/leanprover-community/plausible",
++ [{"url": "https://github.com/leanprover-community/batteries",
+    "type": "git",
+    "subDir": null,
+    "scope": "leanprover-community",
+-   "rev": "42dc02bdbc5d0c2f395718462a76c3d87318f7fa",
+-   "name": "plausible",
++   "rev": "76e9ebe4176d29cb9cc89c669ab9f1ce32b33c3d",
++   "name": "batteries",
+    "manifestFile": "lake-manifest.json",
+    "inputRev": "main",
+    "inherited": true,
+    "configFile": "lakefile.toml"},
+-  {"url": "https://github.com/leanprover-community/LeanSearchClient",
++  {"url": "https://github.com/leanprover-community/quote4",
+    "type": "git",
+    "subDir": null,
+    "scope": "leanprover-community",
+-   "rev": "d7caecce0d0f003fd5e9cce9a61f1dd6ba83142b",
+-   "name": "LeanSearchClient",
++   "rev": "303b23fbcea94ac4f96e590c1cad6618fd4f5f41",
++   "name": "Qq",
+    "manifestFile": "lake-manifest.json",
+-   "inputRev": "main",
++   "inputRev": "master",
+    "inherited": true,
+-   "configFile": "lakefile.toml"},
+-  {"url": "https://github.com/leanprover-community/import-graph",
++   "configFile": "lakefile.lean"},
++  {"url": "https://github.com/leanprover-community/aesop",
+    "type": "git",
+    "subDir": null,
+    "scope": "leanprover-community",
+-   "rev": "519e509a28864af5bed98033dd33b95cf08e9aa7",
+-   "name": "importGraph",
++   "rev": "45d016d59cf45bcf8493a203e9564cfec5203d9b",
++   "name": "aesop",
+    "manifestFile": "lake-manifest.json",
+-   "inputRev": "v4.14.0",
++   "inputRev": "master",
+    "inherited": true,
+    "configFile": "lakefile.toml"},
+   {"url": "https://github.com/leanprover-community/ProofWidgets4",
+    "type": "git",
+    "subDir": null,
+    "scope": "leanprover-community",
+-   "rev": "68280daef58803f68368eb2e53046dabcd270c9d",
++   "rev": "1383e72b40dd62a566896a6e348ffe868801b172",
+    "name": "proofwidgets",
+    "manifestFile": "lake-manifest.json",
+-   "inputRev": "v0.0.47",
++   "inputRev": "v0.0.46",
+    "inherited": true,
+    "configFile": "lakefile.lean"},
+-  {"url": "https://github.com/leanprover-community/aesop",
++  {"url": "https://github.com/leanprover/lean4-cli",
+    "type": "git",
+    "subDir": null,
+-   "scope": "leanprover-community",
+-   "rev": "5a0ec8588855265ade536f35bcdcf0fb24fd6030",
+-   "name": "aesop",
++   "scope": "leanprover",
++   "rev": "726b3c9ad13acca724d4651f14afc4804a7b0e4d",
++   "name": "Cli",
+    "manifestFile": "lake-manifest.json",
+-   "inputRev": "v4.14.0",
++   "inputRev": "main",
+    "inherited": true,
+    "configFile": "lakefile.toml"},
+-  {"url": "https://github.com/leanprover-community/quote4",
++  {"url": "https://github.com/leanprover-community/import-graph",
+    "type": "git",
+    "subDir": null,
+    "scope": "leanprover-community",
+-   "rev": "303b23fbcea94ac4f96e590c1cad6618fd4f5f41",
+-   "name": "Qq",
++   "rev": "ac7b989cbf99169509433124ae484318e953d201",
++   "name": "importGraph",
+    "manifestFile": "lake-manifest.json",
+-   "inputRev": "master",
++   "inputRev": "main",
+    "inherited": true,
+-   "configFile": "lakefile.lean"},
+-  {"url": "https://github.com/leanprover-community/batteries",
++   "configFile": "lakefile.toml"},
++  {"url": "https://github.com/leanprover-community/LeanSearchClient",
+    "type": "git",
+    "subDir": null,
+    "scope": "leanprover-community",
+-   "rev": "8d6c853f11a5172efa0e96b9f2be1a83d861cdd9",
+-   "name": "batteries",
++   "rev": "7bedaed1ef024add1e171cc17706b012a9a37802",
++   "name": "LeanSearchClient",
+    "manifestFile": "lake-manifest.json",
+-   "inputRev": "v4.14.0",
++   "inputRev": "main",
+    "inherited": true,
+    "configFile": "lakefile.toml"},
+-  {"url": "https://github.com/leanprover/lean4-cli",
++  {"url": "https://github.com/leanprover-community/plausible",
+    "type": "git",
+    "subDir": null,
+-   "scope": "leanprover",
+-   "rev": "726b3c9ad13acca724d4651f14afc4804a7b0e4d",
+-   "name": "Cli",
++   "scope": "leanprover-community",
++   "rev": "0f1430e6f1193929f13905d450b2a44a54f3927e",
++   "name": "plausible",
+    "manifestFile": "lake-manifest.json",
+    "inputRev": "main",
+    "inherited": true,
+-   "configFile": "lakefile.toml"}],
++   "configFile": "lakefile.toml"},
++  {"url": "https://github.com/leanprover-community/mathlib4",
++   "type": "git",
++   "subDir": null,
++   "scope": "",
++   "rev": "a7fc949f1b05c2a01e01c027fd9f480496a1253e",
++   "name": "mathlib",
++   "manifestFile": "lake-manifest.json",
++   "inputRev": "v4.14.0-rc1",
++   "inherited": false,
++   "configFile": "lakefile.lean"}],
+  "name": "«repl-mathlib-tests»",
+  "lakeDir": ".lake"}
+diff --git a/test/Mathlib/lakefile.toml b/test/Mathlib/lakefile.toml
+index 6ff9631..0e662ff 100644
+--- a/test/Mathlib/lakefile.toml
++++ b/test/Mathlib/lakefile.toml
+@@ -4,7 +4,7 @@ defaultTargets = ["ReplMathlibTests"]
+ [[require]]
+ name = "mathlib"
+ git = "https://github.com/leanprover-community/mathlib4"
+-rev = "v4.14.0"
++rev = "v4.14.0-rc1"
+ 
+ [[lean_lib]]
+ name = "ReplMathlibTests"
+diff --git a/test/Mathlib/lean-toolchain b/test/Mathlib/lean-toolchain
+index 401bc14..0bef727 100644
+--- a/test/Mathlib/lean-toolchain
++++ b/test/Mathlib/lean-toolchain
+@@ -1 +1 @@
+-leanprover/lean4:v4.14.0
+\ No newline at end of file
++leanprover/lean4:v4.14.0-rc1
+diff --git a/versions/v4.14.0-rc1.diff b/versions/v4.14.0-rc1.diff
+index fff1539..3ba7b47 100644
+--- a/versions/v4.14.0-rc1.diff
++++ b/versions/v4.14.0-rc1.diff
+@@ -1,7 +0,0 @@
+-diff --git a/lean-toolchain b/lean-toolchain
+-index 1e70935..0bef727 100644
+---- a/lean-toolchain
+-+++ b/lean-toolchain
+-@@ -1 +1 @@
+--leanprover/lean4:v4.14.0
+-+leanprover/lean4:v4.14.0-rc1

--- a/versions/v4.14.0-rc2.diff
+++ b/versions/v4.14.0-rc2.diff
@@ -5,3 +5,29 @@ index 1e70935..57a4710 100644
 @@ -1 +1 @@
 -leanprover/lean4:v4.14.0
 +leanprover/lean4:v4.14.0-rc2
+diff --git a/test.sh b/test.sh
+index 070ce3d..6b71a78 100755
+--- a/test.sh
++++ b/test.sh
+@@ -41,6 +41,6 @@ for infile in $IN_DIR/*.in; do
+ 
+ done
+ 
+-# Run the Mathlib tests
+-cp lean-toolchain test/Mathlib/
+-cd test/Mathlib/ && ./test.sh
++# Run the Mathlib tests - skipped as no Mathlib releases exist for v4.14.0-rc2
++# cp lean-toolchain test/Mathlib/
++# cd test/Mathlib/ && ./test.sh
+diff --git a/versions/v4.14.0-rc2.diff b/versions/v4.14.0-rc2.diff
+index 644b7ed..e69de29 100644
+--- a/versions/v4.14.0-rc2.diff
++++ b/versions/v4.14.0-rc2.diff
+@@ -1,7 +0,0 @@
+-diff --git a/lean-toolchain b/lean-toolchain
+-index 1e70935..57a4710 100644
+---- a/lean-toolchain
+-+++ b/lean-toolchain
+-@@ -1 +1 @@
+--leanprover/lean4:v4.14.0
+-+leanprover/lean4:v4.14.0-rc2

--- a/versions/v4.14.0-rc2.diff
+++ b/versions/v4.14.0-rc2.diff
@@ -10,24 +10,12 @@ index 070ce3d..6b71a78 100755
 --- a/test.sh
 +++ b/test.sh
 @@ -41,6 +41,6 @@ for infile in $IN_DIR/*.in; do
- 
+
  done
- 
+
 -# Run the Mathlib tests
 -cp lean-toolchain test/Mathlib/
 -cd test/Mathlib/ && ./test.sh
 +# Run the Mathlib tests - skipped as no Mathlib releases exist for v4.14.0-rc2
 +# cp lean-toolchain test/Mathlib/
 +# cd test/Mathlib/ && ./test.sh
-diff --git a/versions/v4.14.0-rc2.diff b/versions/v4.14.0-rc2.diff
-index 644b7ed..e69de29 100644
---- a/versions/v4.14.0-rc2.diff
-+++ b/versions/v4.14.0-rc2.diff
-@@ -1,7 +0,0 @@
--diff --git a/lean-toolchain b/lean-toolchain
--index 1e70935..57a4710 100644
----- a/lean-toolchain
--+++ b/lean-toolchain
--@@ -1 +1 @@
---leanprover/lean4:v4.14.0
--+leanprover/lean4:v4.14.0-rc2

--- a/versions/v4.14.0-rc2.diff
+++ b/versions/v4.14.0-rc2.diff
@@ -1,0 +1,7 @@
+diff --git a/lean-toolchain b/lean-toolchain
+index 1e70935..57a4710 100644
+--- a/lean-toolchain
++++ b/lean-toolchain
+@@ -1 +1 @@
+-leanprover/lean4:v4.14.0
++leanprover/lean4:v4.14.0-rc2

--- a/versions/v4.14.0-rc3.diff
+++ b/versions/v4.14.0-rc3.diff
@@ -10,24 +10,12 @@ index 070ce3d..0132b9f 100755
 --- a/test.sh
 +++ b/test.sh
 @@ -41,6 +41,6 @@ for infile in $IN_DIR/*.in; do
- 
+
  done
- 
+
 -# Run the Mathlib tests
 -cp lean-toolchain test/Mathlib/
 -cd test/Mathlib/ && ./test.sh
 +# Run the Mathlib tests - skipped as no Mathlib releases exist for v4.14.0-rc3
 +# cp lean-toolchain test/Mathlib/
 +# cd test/Mathlib/ && ./test.sh
-diff --git a/versions/v4.14.0-rc3.diff b/versions/v4.14.0-rc3.diff
-index 9b3b945..e69de29 100644
---- a/versions/v4.14.0-rc3.diff
-+++ b/versions/v4.14.0-rc3.diff
-@@ -1,7 +0,0 @@
--diff --git a/lean-toolchain b/lean-toolchain
--index 1e70935..6d9e70f 100644
----- a/lean-toolchain
--+++ b/lean-toolchain
--@@ -1 +1 @@
---leanprover/lean4:v4.14.0
--+leanprover/lean4:v4.14.0-rc3

--- a/versions/v4.14.0-rc3.diff
+++ b/versions/v4.14.0-rc3.diff
@@ -1,0 +1,7 @@
+diff --git a/lean-toolchain b/lean-toolchain
+index 1e70935..6d9e70f 100644
+--- a/lean-toolchain
++++ b/lean-toolchain
+@@ -1 +1 @@
+-leanprover/lean4:v4.14.0
++leanprover/lean4:v4.14.0-rc3

--- a/versions/v4.14.0-rc3.diff
+++ b/versions/v4.14.0-rc3.diff
@@ -5,3 +5,29 @@ index 1e70935..6d9e70f 100644
 @@ -1 +1 @@
 -leanprover/lean4:v4.14.0
 +leanprover/lean4:v4.14.0-rc3
+diff --git a/test.sh b/test.sh
+index 070ce3d..0132b9f 100755
+--- a/test.sh
++++ b/test.sh
+@@ -41,6 +41,6 @@ for infile in $IN_DIR/*.in; do
+ 
+ done
+ 
+-# Run the Mathlib tests
+-cp lean-toolchain test/Mathlib/
+-cd test/Mathlib/ && ./test.sh
++# Run the Mathlib tests - skipped as no Mathlib releases exist for v4.14.0-rc3
++# cp lean-toolchain test/Mathlib/
++# cd test/Mathlib/ && ./test.sh
+diff --git a/versions/v4.14.0-rc3.diff b/versions/v4.14.0-rc3.diff
+index 9b3b945..e69de29 100644
+--- a/versions/v4.14.0-rc3.diff
++++ b/versions/v4.14.0-rc3.diff
+@@ -1,7 +0,0 @@
+-diff --git a/lean-toolchain b/lean-toolchain
+-index 1e70935..6d9e70f 100644
+---- a/lean-toolchain
+-+++ b/lean-toolchain
+-@@ -1 +1 @@
+--leanprover/lean4:v4.14.0
+-+leanprover/lean4:v4.14.0-rc3

--- a/versions/v4.7.0-rc1.diff
+++ b/versions/v4.7.0-rc1.diff
@@ -180,6 +180,27 @@ index f80f175..7eec48b 100644
   "packagesDir": ".lake/packages",
   "packages": [],
   "name": "REPL",
+diff --git a/lakefile.lean b/lakefile.lean
+new file mode 100644
+index 0000000..33dd0da
+--- /dev/null
++++ b/lakefile.lean
+@@ -0,0 +1,15 @@
++import Lake
++open Lake DSL
++
++package REPL {
++  -- add package configuration options here
++}
++
++lean_lib REPL {
++  -- add library configuration options here
++}
++
++@[default_target]
++lean_exe repl where
++  root := `REPL.Main
++  supportInterpreter := true
 diff --git a/lakefile.toml b/lakefile.toml
 deleted file mode 100644
 index 589e047..0000000
@@ -335,6 +356,23 @@ index f312e5a..812c31d 100644
 +   "configFile": "lakefile.lean"}],
   "name": "«repl-mathlib-tests»",
   "lakeDir": ".lake"}
+diff --git a/test/Mathlib/lakefile.lean b/test/Mathlib/lakefile.lean
+new file mode 100644
+index 0000000..34c561d
+--- /dev/null
++++ b/test/Mathlib/lakefile.lean
+@@ -0,0 +1,11 @@
++import Lake
++open Lake DSL
++
++package «repl-mathlib-tests» where
++  -- add package configuration options here
++  require mathlib from git "https://github.com/leanprover-community/mathlib4" @ "v4.7.0-rc1"
++
++@[default_target]
++lean_lib «ReplMathlibTests» where
++  globs := #[.submodules `test]
++  -- add library configuration options here
 diff --git a/test/Mathlib/lakefile.toml b/test/Mathlib/lakefile.toml
 deleted file mode 100644
 index 6ff9631..0000000

--- a/versions/v4.7.0-rc1.diff
+++ b/versions/v4.7.0-rc1.diff
@@ -1,0 +1,634 @@
+diff --git a/REPL/Frontend.lean b/REPL/Frontend.lean
+index 9cc0914..a2bb150 100644
+--- a/REPL/Frontend.lean
++++ b/REPL/Frontend.lean
+@@ -20,7 +20,10 @@ def processCommandsWithInfoTrees
+     (commandState : Command.State) : IO (Command.State × List Message × List InfoTree) := do
+   let commandState := { commandState with infoState.enabled := true }
+   let s ← IO.processCommands inputCtx parserState commandState <&> Frontend.State.commandState
+-  pure (s, s.messages.toList, s.infoState.trees.toList)
++  let msgs := s.messages.toList.drop commandState.messages.toList.length
++  let trees := s.infoState.trees.toList.drop commandState.infoState.trees.size
++
++  pure (s, msgs, trees)
+ 
+ /--
+ Process some text input, with or without an existing command state.
+diff --git a/REPL/JSON.lean b/REPL/JSON.lean
+index d5c5ba2..b63c5ea 100644
+--- a/REPL/JSON.lean
++++ b/REPL/JSON.lean
+@@ -83,7 +83,7 @@ structure Sorry where
+ deriving FromJson
+ 
+ instance : ToJson Sorry where
+-  toJson r := Json.mkObj <| .flatten [
++  toJson r := Json.mkObj <| .join [
+     [("goal", r.goal)],
+     [("proofState", toJson r.proofState)],
+     if r.pos.line ≠ 0 then [("pos", toJson r.pos)] else [],
+@@ -132,7 +132,7 @@ def Json.nonemptyList [ToJson α] (k : String) : List α → List (String × Jso
+   | l  => [⟨k, toJson l⟩]
+ 
+ instance : ToJson CommandResponse where
+-  toJson r := Json.mkObj <| .flatten [
++  toJson r := Json.mkObj <| .join [
+     [("env", r.env)],
+     Json.nonemptyList "messages" r.messages,
+     Json.nonemptyList "sorries" r.sorries,
+@@ -153,7 +153,7 @@ structure ProofStepResponse where
+ deriving ToJson, FromJson
+ 
+ instance : ToJson ProofStepResponse where
+-  toJson r := Json.mkObj <| .flatten [
++  toJson r := Json.mkObj <| .join [
+     [("proofState", r.proofState)],
+     [("goals", toJson r.goals)],
+     Json.nonemptyList "messages" r.messages,
+diff --git a/REPL/Lean/Environment.lean b/REPL/Lean/Environment.lean
+index 0b4be3c..61d4e76 100644
+--- a/REPL/Lean/Environment.lean
++++ b/REPL/Lean/Environment.lean
+@@ -26,6 +26,6 @@ and then replace the new constants.
+ def unpickle (path : FilePath) : IO (Environment × CompactedRegion) := unsafe do
+   let ((imports, map₂), region) ← _root_.unpickle (Array Import × PHashMap Name ConstantInfo) path
+   let env ← importModules imports {} 0
+-  return (← env.replay (Std.HashMap.ofList map₂.toList), region)
++  return (← env.replay (HashMap.ofList map₂.toList), region)
+ 
+ end Lean.Environment
+diff --git a/REPL/Lean/InfoTree.lean b/REPL/Lean/InfoTree.lean
+index 7abf0b8..d3b28c1 100644
+--- a/REPL/Lean/InfoTree.lean
++++ b/REPL/Lean/InfoTree.lean
+@@ -131,9 +131,9 @@ partial def filter (p : Info → Bool) (m : MVarId → Bool := fun _ => false) :
+   | .context ctx tree => tree.filter p m |>.map (.context ctx)
+   | .node info children =>
+     if p info then
+-      [.node info (children.toList.map (filter p m)).flatten.toPArray']
++      [.node info (children.toList.map (filter p m)).join.toPArray']
+     else
+-      (children.toList.map (filter p m)).flatten
++      (children.toList.map (filter p m)).join
+   | .hole mvar => if m mvar then [.hole mvar] else []
+ 
+ /-- Discard all nodes besides `.context` nodes and `TacticInfo` nodes. -/
+@@ -156,7 +156,7 @@ partial def findAllInfo (t : InfoTree) (ctx? : Option ContextInfo) (p : Info →
+   | context ctx t => t.findAllInfo (ctx.mergeIntoOuter? ctx?) p
+   | node i ts  =>
+     let info := if p i then [(i, ctx?)] else []
+-    let rest := ts.toList.flatMap (fun t => t.findAllInfo ctx? p)
++    let rest := ts.toList.bind (fun t => t.findAllInfo ctx? p)
+     info ++ rest
+   | _ => []
+ 
+@@ -214,13 +214,13 @@ def sorries (t : InfoTree) : List (ContextInfo × SorryType × Position × Posit
+ 
+ def tactics (t : InfoTree) : List (ContextInfo × Syntax × List MVarId × Position × Position × Array Name) :=
+     -- HACK: creating a child ngen
+-  t.findTacticNodes.map fun ⟨i, ctx⟩ => 
+-    let range := stxRange ctx.fileMap i.stx 
+-    ( { ctx with mctx := i.mctxBefore, ngen := ctx.ngen.mkChild.1 }, 
+-      i.stx, 
+-      i.goalsBefore, 
+-      range.fst, 
+-      range.snd, 
++  t.findTacticNodes.map fun ⟨i, ctx⟩ =>
++    let range := stxRange ctx.fileMap i.stx
++    ( { ctx with mctx := i.mctxBefore, ngen := ctx.ngen.mkChild.1 },
++      i.stx,
++      i.goalsBefore,
++      range.fst,
++      range.snd,
+       i.getUsedConstantsAsSet.toArray )
+ 
+ 
+diff --git a/REPL/Main.lean b/REPL/Main.lean
+index a4b97c3..51f2d4a 100644
+--- a/REPL/Main.lean
++++ b/REPL/Main.lean
+@@ -95,7 +95,7 @@ def recordProofSnapshot (proofState : ProofSnapshot) : M m Nat := do
+   return id
+ 
+ def sorries (trees : List InfoTree) (env? : Option Environment) : M m (List Sorry) :=
+-  trees.flatMap InfoTree.sorries |>.filter (fun t => match t.2.1 with
++  trees.bind InfoTree.sorries |>.filter (fun t => match t.2.1 with
+     | .term _ none => false
+     | _ => true ) |>.mapM
+       fun ⟨ctx, g, pos, endPos⟩ => do
+@@ -117,7 +117,7 @@ def ppTactic (ctx : ContextInfo) (stx : Syntax) : IO Format :=
+     pure "<failed to pretty print>"
+ 
+ def tactics (trees : List InfoTree) : M m (List Tactic) :=
+-  trees.flatMap InfoTree.tactics |>.mapM
++  trees.bind InfoTree.tactics |>.mapM
+     fun ⟨ctx, stx, goals, pos, endPos, ns⟩ => do
+       let proofState := some (← ProofSnapshot.create ctx none none goals)
+       let goals := s!"{(← ctx.ppGoals goals)}".trim
+@@ -212,15 +212,13 @@ def runCommand (s : Command) : M IO (CommandResponse ⊕ Error) := do
+     cmdContext := (cmdSnapshot?.map fun c => c.cmdContext).getD
+       { fileName := "",
+         fileMap := default,
+-        tacticCache? := none,
+-        snap? := none,
+-        cancelTk? := none } }
++        tacticCache? := none } }
+   let env ← recordCommandSnapshot cmdSnapshot
+   let jsonTrees := match s.infotree with
+   | some "full" => trees
+-  | some "tactics" => trees.flatMap InfoTree.retainTacticInfo
+-  | some "original" => trees.flatMap InfoTree.retainTacticInfo |>.flatMap InfoTree.retainOriginal
+-  | some "substantive" => trees.flatMap InfoTree.retainTacticInfo |>.flatMap InfoTree.retainSubstantive
++  | some "tactics" => trees.bind InfoTree.retainTacticInfo
++  | some "original" => trees.bind InfoTree.retainTacticInfo |>.bind InfoTree.retainOriginal
++  | some "substantive" => trees.bind InfoTree.retainTacticInfo |>.bind InfoTree.retainSubstantive
+   | _ => []
+   let infotree ← if jsonTrees.isEmpty then
+     pure none
+diff --git a/REPL/Snapshots.lean b/REPL/Snapshots.lean
+index 1114c24..7462141 100644
+--- a/REPL/Snapshots.lean
++++ b/REPL/Snapshots.lean
+@@ -83,7 +83,7 @@ def unpickle (path : FilePath) : IO (CommandSnapshot × CompactedRegion) := unsa
+   let ((imports, map₂, cmdState, cmdContext), region) ←
+     _root_.unpickle (Array Import × PHashMap Name ConstantInfo × CompactableCommandSnapshot ×
+       Command.Context) path
+-  let env ← (← importModules imports {} 0).replay (Std.HashMap.ofList map₂.toList)
++  let env ← (← importModules imports {} 0).replay (HashMap.ofList map₂.toList)
+   let p' : CommandSnapshot :=
+   { cmdState := { cmdState with env }
+     cmdContext }
+@@ -284,9 +284,9 @@ def unpickle (path : FilePath) (cmd? : Option CommandSnapshot) :
+   let env ← match cmd? with
+   | none =>
+     enableInitializersExecution
+-    (← importModules imports {} 0).replay (Std.HashMap.ofList map₂.toList)
++    (← importModules imports {} 0).replay (HashMap.ofList map₂.toList)
+   | some cmd =>
+-    cmd.cmdState.env.replay (Std.HashMap.ofList map₂.toList)
++    cmd.cmdState.env.replay (HashMap.ofList map₂.toList)
+   let p' : ProofSnapshot :=
+   { coreState := { coreState with env }
+     coreContext
+diff --git a/lake-manifest.json b/lake-manifest.json
+index f80f175..7eec48b 100644
+--- a/lake-manifest.json
++++ b/lake-manifest.json
+@@ -1,4 +1,4 @@
+-{"version": "1.1.0",
++{"version": 7,
+  "packagesDir": ".lake/packages",
+  "packages": [],
+  "name": "REPL",
+diff --git a/lakefile.toml b/lakefile.toml
+deleted file mode 100644
+index 589e047..0000000
+--- a/lakefile.toml
++++ /dev/null
+@@ -1,10 +0,0 @@
+-name = "REPL"
+-defaultTargets = ["repl"]
+-
+-[[lean_lib]]
+-name = "REPL"
+-
+-[[lean_exe]]
+-name = "repl"
+-root = "REPL.Main"
+-supportInterpreter = true
+diff --git a/lean-toolchain b/lean-toolchain
+index 1e70935..6b26dd5 100644
+--- a/lean-toolchain
++++ b/lean-toolchain
+@@ -1 +1 @@
+-leanprover/lean4:v4.14.0
++leanprover/lean4:v4.7.0-rc1
+diff --git a/test/Mathlib/lake-manifest.json b/test/Mathlib/lake-manifest.json
+index f312e5a..812c31d 100644
+--- a/test/Mathlib/lake-manifest.json
++++ b/test/Mathlib/lake-manifest.json
+@@ -1,95 +1,68 @@
+-{"version": "1.1.0",
++{"version": 7,
+  "packagesDir": ".lake/packages",
+  "packages":
+- [{"url": "https://github.com/leanprover-community/mathlib4",
++ [{"url": "https://github.com/leanprover/std4",
+    "type": "git",
+    "subDir": null,
+-   "scope": "",
+-   "rev": "4bbdccd9c5f862bf90ff12f0a9e2c8be032b9a84",
+-   "name": "mathlib",
+-   "manifestFile": "lake-manifest.json",
+-   "inputRev": "v4.14.0",
+-   "inherited": false,
+-   "configFile": "lakefile.lean"},
+-  {"url": "https://github.com/leanprover-community/plausible",
+-   "type": "git",
+-   "subDir": null,
+-   "scope": "leanprover-community",
+-   "rev": "42dc02bdbc5d0c2f395718462a76c3d87318f7fa",
+-   "name": "plausible",
++   "rev": "ff9850c4726f6b9fb8d8e96980c3fcb2900be8bd",
++   "name": "std",
+    "manifestFile": "lake-manifest.json",
+    "inputRev": "main",
+    "inherited": true,
+-   "configFile": "lakefile.toml"},
+-  {"url": "https://github.com/leanprover-community/LeanSearchClient",
++   "configFile": "lakefile.lean"},
++  {"url": "https://github.com/leanprover-community/quote4",
+    "type": "git",
+    "subDir": null,
+-   "scope": "leanprover-community",
+-   "rev": "d7caecce0d0f003fd5e9cce9a61f1dd6ba83142b",
+-   "name": "LeanSearchClient",
++   "rev": "fd760831487e6835944e7eeed505522c9dd47563",
++   "name": "Qq",
+    "manifestFile": "lake-manifest.json",
+-   "inputRev": "main",
++   "inputRev": "master",
+    "inherited": true,
+-   "configFile": "lakefile.toml"},
+-  {"url": "https://github.com/leanprover-community/import-graph",
++   "configFile": "lakefile.lean"},
++  {"url": "https://github.com/leanprover-community/aesop",
+    "type": "git",
+    "subDir": null,
+-   "scope": "leanprover-community",
+-   "rev": "519e509a28864af5bed98033dd33b95cf08e9aa7",
+-   "name": "importGraph",
++   "rev": "056ca0fa8f5585539d0b940f532d9750c3a2270f",
++   "name": "aesop",
+    "manifestFile": "lake-manifest.json",
+-   "inputRev": "v4.14.0",
++   "inputRev": "master",
+    "inherited": true,
+-   "configFile": "lakefile.toml"},
++   "configFile": "lakefile.lean"},
+   {"url": "https://github.com/leanprover-community/ProofWidgets4",
+    "type": "git",
+    "subDir": null,
+-   "scope": "leanprover-community",
+-   "rev": "68280daef58803f68368eb2e53046dabcd270c9d",
++   "rev": "fb65c476595a453a9b8ffc4a1cea2db3a89b9cd8",
+    "name": "proofwidgets",
+    "manifestFile": "lake-manifest.json",
+-   "inputRev": "v0.0.47",
++   "inputRev": "v0.0.30",
+    "inherited": true,
+    "configFile": "lakefile.lean"},
+-  {"url": "https://github.com/leanprover-community/aesop",
+-   "type": "git",
+-   "subDir": null,
+-   "scope": "leanprover-community",
+-   "rev": "5a0ec8588855265ade536f35bcdcf0fb24fd6030",
+-   "name": "aesop",
+-   "manifestFile": "lake-manifest.json",
+-   "inputRev": "v4.14.0",
+-   "inherited": true,
+-   "configFile": "lakefile.toml"},
+-  {"url": "https://github.com/leanprover-community/quote4",
++  {"url": "https://github.com/leanprover/lean4-cli",
+    "type": "git",
+    "subDir": null,
+-   "scope": "leanprover-community",
+-   "rev": "303b23fbcea94ac4f96e590c1cad6618fd4f5f41",
+-   "name": "Qq",
++   "rev": "a751d21d4b68c999accb6fc5d960538af26ad5ec",
++   "name": "Cli",
+    "manifestFile": "lake-manifest.json",
+-   "inputRev": "master",
++   "inputRev": "main",
+    "inherited": true,
+    "configFile": "lakefile.lean"},
+-  {"url": "https://github.com/leanprover-community/batteries",
++  {"url": "https://github.com/leanprover-community/import-graph.git",
+    "type": "git",
+    "subDir": null,
+-   "scope": "leanprover-community",
+-   "rev": "8d6c853f11a5172efa0e96b9f2be1a83d861cdd9",
+-   "name": "batteries",
++   "rev": "64d082eeaad1a8e6bbb7c23b7a16b85a1715a02f",
++   "name": "importGraph",
+    "manifestFile": "lake-manifest.json",
+-   "inputRev": "v4.14.0",
++   "inputRev": "main",
+    "inherited": true,
+-   "configFile": "lakefile.toml"},
+-  {"url": "https://github.com/leanprover/lean4-cli",
++   "configFile": "lakefile.lean"},
++  {"url": "https://github.com/leanprover-community/mathlib4",
+    "type": "git",
+    "subDir": null,
+-   "scope": "leanprover",
+-   "rev": "726b3c9ad13acca724d4651f14afc4804a7b0e4d",
+-   "name": "Cli",
++   "rev": "fa48894a5d2780c6593a224003a660ca039e3e8f",
++   "name": "mathlib",
+    "manifestFile": "lake-manifest.json",
+-   "inputRev": "main",
+-   "inherited": true,
+-   "configFile": "lakefile.toml"}],
++   "inputRev": "v4.7.0-rc1",
++   "inherited": false,
++   "configFile": "lakefile.lean"}],
+  "name": "«repl-mathlib-tests»",
+  "lakeDir": ".lake"}
+diff --git a/test/Mathlib/lakefile.toml b/test/Mathlib/lakefile.toml
+deleted file mode 100644
+index 6ff9631..0000000
+--- a/test/Mathlib/lakefile.toml
++++ /dev/null
+@@ -1,11 +0,0 @@
+-name = "«repl-mathlib-tests»"
+-defaultTargets = ["ReplMathlibTests"]
+-
+-[[require]]
+-name = "mathlib"
+-git = "https://github.com/leanprover-community/mathlib4"
+-rev = "v4.14.0"
+-
+-[[lean_lib]]
+-name = "ReplMathlibTests"
+-globs = ["test.+"]
+diff --git a/test/Mathlib/lean-toolchain b/test/Mathlib/lean-toolchain
+index 401bc14..6b26dd5 100644
+--- a/test/Mathlib/lean-toolchain
++++ b/test/Mathlib/lean-toolchain
+@@ -1 +1 @@
+-leanprover/lean4:v4.14.0
+\ No newline at end of file
++leanprover/lean4:v4.7.0-rc1
+diff --git a/test/Mathlib/test/H20231020.in b/test/Mathlib/test/H20231020.in
+index cd3e590..2f3a097 100644
+--- a/test/Mathlib/test/H20231020.in
++++ b/test/Mathlib/test/H20231020.in
+@@ -1,4 +1,4 @@
+-{"cmd": "import Mathlib.Algebra.BigOperators.Group.Finset\nimport Mathlib.Data.Real.Basic\nimport Mathlib.Data.Complex.Basic\nimport Mathlib.Data.Nat.Log\nimport Mathlib.Data.Complex.Exponential\nimport Mathlib.NumberTheory.Divisors\nimport Mathlib.Data.ZMod.Defs\nimport Mathlib.Data.ZMod.Basic\nimport Mathlib.Topology.Basic\nimport Mathlib.Data.Nat.Digits\nimport Mathlib.Tactic.NormNum.GCD\nopen BigOperators\nopen Real\nopen Nat\nopen Topology"}
++{"cmd": "import Mathlib.Algebra.BigOperators.Basic\nimport Mathlib.Data.Real.Basic\nimport Mathlib.Data.Complex.Basic\nimport Mathlib.Data.Nat.Log\nimport Mathlib.Data.Complex.Exponential\nimport Mathlib.NumberTheory.Divisors\nimport Mathlib.Data.ZMod.Defs\nimport Mathlib.Data.ZMod.Basic\nimport Mathlib.Topology.Basic\nimport Mathlib.Data.Nat.Digits\nimport Mathlib.Tactic.NormNum.GCD\nopen BigOperators\nopen Real\nopen Nat\nopen Topology"}
+ 
+ {"cmd": "theorem mathd_numbertheory_188 : Nat.gcd 180 168 = 12 := by norm_num", "env": 0}
+ 
+diff --git a/test/Mathlib/test/H20231020.lean b/test/Mathlib/test/H20231020.lean
+index 670e12b..849e3c4 100644
+--- a/test/Mathlib/test/H20231020.lean
++++ b/test/Mathlib/test/H20231020.lean
+@@ -1,4 +1,4 @@
+-import Mathlib.Algebra.BigOperators.Group.Finset
++import Mathlib.Algebra.BigOperators.Basic
+ import Mathlib.Data.Real.Basic
+ import Mathlib.Data.Complex.Basic
+ import Mathlib.Data.Nat.Log
+diff --git a/test/Mathlib/test/H20231115.expected.out b/test/Mathlib/test/H20231115.expected.out
+index 2efb1d8..f386cb7 100644
+--- a/test/Mathlib/test/H20231115.expected.out
++++ b/test/Mathlib/test/H20231115.expected.out
+@@ -14,6 +14,6 @@
+ 
+ {"proofState": 1,
+  "goals":
+- ["case zero\n⊢ 0 + 1 > 0",
+-  "case succ\nx : Nat\nhx : x + 1 > x\n⊢ x + 1 + 1 > x + 1"]}
++ ["case zero\n⊢ Nat.zero + 1 > Nat.zero",
++  "case succ\nx : Nat\nhx : x + 1 > x\n⊢ Nat.succ x + 1 > Nat.succ x"]}
+ 
+diff --git a/test/Mathlib/test/H20231115_2.expected.out b/test/Mathlib/test/H20231115_2.expected.out
+index 3c19b57..39d6142 100644
+--- a/test/Mathlib/test/H20231115_2.expected.out
++++ b/test/Mathlib/test/H20231115_2.expected.out
+@@ -3,11 +3,11 @@
+ {"sorries":
+  [{"proofState": 0,
+    "pos": {"line": 3, "column": 12},
+-   "goal": "case zero\n⊢ 0 + 1 > 0",
++   "goal": "case zero\n⊢ Nat.zero + 1 > Nat.zero",
+    "endPos": {"line": 3, "column": 17}},
+   {"proofState": 1,
+    "pos": {"line": 3, "column": 12},
+-   "goal": "case succ\nx : Nat\nhx : x + 1 > x\n⊢ x + 1 + 1 > x + 1",
++   "goal": "case succ\nx : Nat\nhx : x + 1 > x\n⊢ Nat.succ x + 1 > Nat.succ x",
+    "endPos": {"line": 3, "column": 17}}],
+  "messages":
+  [{"severity": "warning",
+diff --git a/test/Mathlib/test/H20231115_3.expected.out b/test/Mathlib/test/H20231115_3.expected.out
+index 3b72d40..45b397f 100644
+--- a/test/Mathlib/test/H20231115_3.expected.out
++++ b/test/Mathlib/test/H20231115_3.expected.out
+@@ -5,6 +5,6 @@
+    "pos": {"line": 1, "column": 33},
+    "endPos": {"line": 2, "column": 24},
+    "data":
+-   "unsolved goals\ncase zero\n⊢ 0 + 1 > 0\n\ncase succ\nx : Nat\nhx : x + 1 > x\n⊢ x + 1 + 1 > x + 1"}],
++   "unsolved goals\ncase zero\n⊢ Nat.zero + 1 > Nat.zero\n\ncase succ\nx : Nat\nhx : x + 1 > x\n⊢ Nat.succ x + 1 > Nat.succ x"}],
+  "env": 1}
+ 
+diff --git a/test/Mathlib/test/H20231214.lean b/test/Mathlib/test/H20231214.lean
+index fc8ad1c..24f3f20 100644
+--- a/test/Mathlib/test/H20231214.lean
++++ b/test/Mathlib/test/H20231214.lean
+@@ -12,14 +12,6 @@ but is expected to have type
+   p x = 6 / x * p x : Prop
+ ---
+ error: unsolved goals
+-case calc.step
+-p q : ℝ → ℝ
+-h₀ : ∀ (x : ℝ), p x = 2 - x ^ 2
+-h₁ : ∀ (x : ℝ), x ≠ 0 → q x = 6 / x
+-x : ℝ
+-⊢ 6 / 2 * 6 / x * (6 / x) = 6 / x
+----
+-error: unsolved goals
+ p q : ℝ → ℝ
+ h₀ : ∀ (x : ℝ), p x = 2 - x ^ 2
+ h₁ : ∀ (x : ℝ), x ≠ 0 → q x = 6 / x
+diff --git a/test/Mathlib/test/exact.expected.out b/test/Mathlib/test/exact.expected.out
+index 86cd1c6..1c1a057 100644
+--- a/test/Mathlib/test/exact.expected.out
++++ b/test/Mathlib/test/exact.expected.out
+@@ -17,7 +17,7 @@
+  [{"severity": "info",
+    "pos": {"line": 0, "column": 0},
+    "endPos": {"line": 0, "column": 0},
+-   "data": "Try this: exact Nat.one_pos"}],
++   "data": "Try this: exact Nat.zero_lt_one"}],
+  "goals": []}
+ 
+ {"sorries":
+diff --git a/test/Mathlib/test/exact.in b/test/Mathlib/test/exact.in
+index 72b4c50..5764c0f 100644
+--- a/test/Mathlib/test/exact.in
++++ b/test/Mathlib/test/exact.in
+@@ -1,4 +1,4 @@
+-{"cmd": "import Mathlib"}
++{"cmd": "import Mathlib\n\nset_option maxHeartbeats 500000"}
+ 
+ {"cmd": "theorem test : 0 < 1 := by sorry", "env": 0}
+ 
+diff --git a/test/Mathlib/test/induction.expected.out b/test/Mathlib/test/induction.expected.out
+index 7ef34d3..8e19362 100644
+--- a/test/Mathlib/test/induction.expected.out
++++ b/test/Mathlib/test/induction.expected.out
+@@ -14,14 +14,16 @@
+ 
+ {"proofState": 1,
+  "goals":
+- ["case zero\n⊢ 0 = 0", "case succ\nn✝ : ℕ\na✝ : n✝ = n✝\n⊢ n✝ + 1 = n✝ + 1"]}
++ ["case zero\n⊢ Nat.zero = Nat.zero",
++  "case succ\nn✝ : ℕ\nn_ih✝ : n✝ = n✝\n⊢ Nat.succ n✝ = Nat.succ n✝"]}
+ 
+ {"proofState": 2,
+- "goals": ["case succ\nn✝ : ℕ\na✝ : n✝ = n✝\n⊢ n✝ + 1 = n✝ + 1"]}
++ "goals": ["case succ\nn✝ : ℕ\nn_ih✝ : n✝ = n✝\n⊢ Nat.succ n✝ = Nat.succ n✝"]}
+ 
+ {"sorries":
+- [{"proofState": 3, "goal": "case zero\n⊢ 0 = 0"},
+-  {"proofState": 4, "goal": "case succ\nx : ℕ\na✝ : x = x\n⊢ x + 1 = x + 1"}],
++ [{"proofState": 3, "goal": "case zero\n⊢ Nat.zero = Nat.zero"},
++  {"proofState": 4,
++   "goal": "case succ\nx : ℕ\nn_ih✝ : x = x\n⊢ Nat.succ x = Nat.succ x"}],
+  "proofState": 5,
+  "goals": []}
+ 
+diff --git a/test/all_tactics.expected.out b/test/all_tactics.expected.out
+index 6ec808c..5374db8 100644
+--- a/test/all_tactics.expected.out
++++ b/test/all_tactics.expected.out
+@@ -9,7 +9,7 @@
+    "tactic": "exact t",
+    "proofState": 1,
+    "pos": {"line": 1, "column": 32},
+-   "goals": "t : Nat\n⊢ Nat",
++   "goals": "t : Nat ⊢ Nat",
+    "endPos": {"line": 1, "column": 39}}],
+  "env": 0}
+ 
+diff --git a/test/calc.expected.out b/test/calc.expected.out
+index 94f6a9f..fde8fee 100644
+--- a/test/calc.expected.out
++++ b/test/calc.expected.out
+@@ -1,35 +1,22 @@
+ {"tactics":
+  [{"usedConstants":
+-   ["Trans.trans",
+-    "sorryAx",
+-    "instOfNatNat",
+-    "instTransEq",
+-    "Nat",
+-    "OfNat.ofNat",
+-    "Bool.false",
+-    "Eq"],
++   ["Trans.trans", "instOfNatNat", "instTransEq", "Nat", "OfNat.ofNat", "Eq"],
+    "tactic": "calc\n  3 = 4 := by sorry\n  4 = 5 := by sorry",
+    "proofState": 2,
+    "pos": {"line": 1, "column": 22},
+    "goals": "⊢ 3 = 5",
+    "endPos": {"line": 3, "column": 19}},
+-  {"usedConstants": [],
+-   "tactic": "\n  3 = 4 := by sorry\n  4 = 5 := by sorry",
+-   "proofState": 3,
+-   "pos": {"line": 2, "column": 2},
+-   "goals": "no goals",
+-   "endPos": {"line": 3, "column": 19}},
+   {"usedConstants":
+    ["sorryAx", "instOfNatNat", "Nat", "OfNat.ofNat", "Bool.false", "Eq"],
+    "tactic": "sorry",
+-   "proofState": 4,
++   "proofState": 3,
+    "pos": {"line": 2, "column": 14},
+    "goals": "⊢ 3 = 4",
+    "endPos": {"line": 2, "column": 19}},
+   {"usedConstants":
+    ["sorryAx", "instOfNatNat", "Nat", "OfNat.ofNat", "Bool.false", "Eq"],
+    "tactic": "sorry",
+-   "proofState": 5,
++   "proofState": 4,
+    "pos": {"line": 3, "column": 14},
+    "goals": "⊢ 4 = 5",
+    "endPos": {"line": 3, "column": 19}}],
+diff --git a/test/infotree.expected.out b/test/infotree.expected.out
+index cb76c20..236e1ba 100644
+--- a/test/infotree.expected.out
++++ b/test/infotree.expected.out
+@@ -2,8 +2,7 @@
+  [{"severity": "warning",
+    "pos": {"line": 1, "column": 7},
+    "endPos": {"line": 1, "column": 8},
+-   "data":
+-   "unused variable `h`\nnote: this linter can be disabled with `set_option linter.unusedVariables false`"}],
++   "data": "unused variable `h` [linter.unusedVariables]"}],
+  "infotree":
+  [{"node":
+    {"stx":
+diff --git a/test/name_generator.expected.out b/test/name_generator.expected.out
+index b4d885b..557d03b 100644
+--- a/test/name_generator.expected.out
++++ b/test/name_generator.expected.out
+@@ -24,13 +24,13 @@
+  "goals": []}
+ 
+ {"traces":
+- ["[Meta.Tactic.simp.rewrite] gt_iff_lt:1000, x > 0 ==> 0 < x",
++ ["[Meta.Tactic.simp.rewrite] @gt_iff_lt:1000, x > 0 ==> 0 < x",
+   "[Meta.Tactic.simp.rewrite] h0:1000, 0 < x ==> True"],
+  "proofState": 6,
+  "goals": []}
+ 
+ {"traces":
+- ["[Meta.Tactic.simp.rewrite] gt_iff_lt:1000, x > 0 ==> 0 < x",
++ ["[Meta.Tactic.simp.rewrite] @gt_iff_lt:1000, x > 0 ==> 0 < x",
+   "[Meta.Tactic.simp.rewrite] h0:1000, 0 < x ==> True"],
+  "proofState": 7,
+  "goals": []}
+diff --git a/test/no_goal_sorry.expected.out b/test/no_goal_sorry.expected.out
+index 5c89f5a..5be11b7 100644
+--- a/test/no_goal_sorry.expected.out
++++ b/test/no_goal_sorry.expected.out
+@@ -4,8 +4,8 @@
+    "endPos": {"line": 2, "column": 18},
+    "data": "type expected, got\n  (set Nat : ?m.8 PUnit)"},
+   {"severity": "error",
+-   "pos": {"line": 2, "column": 22},
+-   "endPos": {"line": 2, "column": 24},
+-   "data": "Case tag 'body' not found.\n\nThere are no cases to select."}],
++   "pos": {"line": 3, "column": 2},
++   "endPos": {"line": 3, "column": 7},
++   "data": "no goals to be solved"}],
+  "env": 0}
+ 
+diff --git a/test/trace_simp.expected.out b/test/trace_simp.expected.out
+index 2a85844..1f6fbeb 100644
+--- a/test/trace_simp.expected.out
++++ b/test/trace_simp.expected.out
+@@ -9,7 +9,7 @@
+    "pos": {"line": 1, "column": 23},
+    "endPos": {"line": 1, "column": 27},
+    "data":
+-   "[Meta.Tactic.simp.rewrite] f_def:1000, f ==> 37\n[Meta.Tactic.simp.rewrite] eq_self:1000, 37 = 37 ==> True"}],
++   "[Meta.Tactic.simp.rewrite] f_def:1000, f ==> 37\n[Meta.Tactic.simp.rewrite] @eq_self:1000, 37 = 37 ==> True"}],
+  "env": 3}
+ 
+ {"sorries":
+@@ -28,7 +28,7 @@
+ 
+ {"traces":
+  ["[Meta.Tactic.simp.rewrite] f_def:1000, f ==> 37",
+-  "[Meta.Tactic.simp.rewrite] eq_self:1000, 37 = 37 ==> True"],
++  "[Meta.Tactic.simp.rewrite] @eq_self:1000, 37 = 37 ==> True"],
+  "proofState": 2,
+  "goals": []}
+ 
+diff --git a/test/variables.expected.out b/test/variables.expected.out
+index cd060cb..1504f9b 100644
+--- a/test/variables.expected.out
++++ b/test/variables.expected.out
+@@ -4,8 +4,7 @@
+  [{"severity": "warning",
+    "pos": {"line": 1, "column": 12},
+    "endPos": {"line": 1, "column": 13},
+-   "data":
+-   "unused variable `y`\nnote: this linter can be disabled with `set_option linter.unusedVariables false`"}],
++   "data": "unused variable `y` [linter.unusedVariables]"}],
+  "env": 1}
+ 
+ {"sorries":

--- a/versions/v4.7.0-rc1.diff
+++ b/versions/v4.7.0-rc1.diff
@@ -11,7 +11,7 @@ index 9cc0914..a2bb150 100644
 +  let trees := s.infoState.trees.toList.drop commandState.infoState.trees.size
 +
 +  pure (s, msgs, trees)
- 
+
  /--
  Process some text input, with or without an existing command state.
 diff --git a/REPL/JSON.lean b/REPL/JSON.lean
@@ -20,7 +20,7 @@ index d5c5ba2..b63c5ea 100644
 +++ b/REPL/JSON.lean
 @@ -83,7 +83,7 @@ structure Sorry where
  deriving FromJson
- 
+
  instance : ToJson Sorry where
 -  toJson r := Json.mkObj <| .flatten [
 +  toJson r := Json.mkObj <| .join [
@@ -29,7 +29,7 @@ index d5c5ba2..b63c5ea 100644
      if r.pos.line ≠ 0 then [("pos", toJson r.pos)] else [],
 @@ -132,7 +132,7 @@ def Json.nonemptyList [ToJson α] (k : String) : List α → List (String × Jso
    | l  => [⟨k, toJson l⟩]
- 
+
  instance : ToJson CommandResponse where
 -  toJson r := Json.mkObj <| .flatten [
 +  toJson r := Json.mkObj <| .join [
@@ -38,7 +38,7 @@ index d5c5ba2..b63c5ea 100644
      Json.nonemptyList "sorries" r.sorries,
 @@ -153,7 +153,7 @@ structure ProofStepResponse where
  deriving ToJson, FromJson
- 
+
  instance : ToJson ProofStepResponse where
 -  toJson r := Json.mkObj <| .flatten [
 +  toJson r := Json.mkObj <| .join [
@@ -55,7 +55,7 @@ index 0b4be3c..61d4e76 100644
    let env ← importModules imports {} 0
 -  return (← env.replay (Std.HashMap.ofList map₂.toList), region)
 +  return (← env.replay (HashMap.ofList map₂.toList), region)
- 
+
  end Lean.Environment
 diff --git a/REPL/Lean/InfoTree.lean b/REPL/Lean/InfoTree.lean
 index 7abf0b8..d3b28c1 100644
@@ -71,7 +71,7 @@ index 7abf0b8..d3b28c1 100644
 -      (children.toList.map (filter p m)).flatten
 +      (children.toList.map (filter p m)).join
    | .hole mvar => if m mvar then [.hole mvar] else []
- 
+
  /-- Discard all nodes besides `.context` nodes and `TacticInfo` nodes. -/
 @@ -156,7 +156,7 @@ partial def findAllInfo (t : InfoTree) (ctx? : Option ContextInfo) (p : Info →
    | context ctx t => t.findAllInfo (ctx.mergeIntoOuter? ctx?) p
@@ -81,18 +81,18 @@ index 7abf0b8..d3b28c1 100644
 +    let rest := ts.toList.bind (fun t => t.findAllInfo ctx? p)
      info ++ rest
    | _ => []
- 
+
 @@ -214,13 +214,13 @@ def sorries (t : InfoTree) : List (ContextInfo × SorryType × Position × Posit
- 
+
  def tactics (t : InfoTree) : List (ContextInfo × Syntax × List MVarId × Position × Position × Array Name) :=
      -- HACK: creating a child ngen
--  t.findTacticNodes.map fun ⟨i, ctx⟩ => 
--    let range := stxRange ctx.fileMap i.stx 
--    ( { ctx with mctx := i.mctxBefore, ngen := ctx.ngen.mkChild.1 }, 
--      i.stx, 
--      i.goalsBefore, 
--      range.fst, 
--      range.snd, 
+-  t.findTacticNodes.map fun ⟨i, ctx⟩ =>
+-    let range := stxRange ctx.fileMap i.stx
+-    ( { ctx with mctx := i.mctxBefore, ngen := ctx.ngen.mkChild.1 },
+-      i.stx,
+-      i.goalsBefore,
+-      range.fst,
+-      range.snd,
 +  t.findTacticNodes.map fun ⟨i, ctx⟩ =>
 +    let range := stxRange ctx.fileMap i.stx
 +    ( { ctx with mctx := i.mctxBefore, ngen := ctx.ngen.mkChild.1 },
@@ -101,15 +101,15 @@ index 7abf0b8..d3b28c1 100644
 +      range.fst,
 +      range.snd,
        i.getUsedConstantsAsSet.toArray )
- 
- 
+
+
 diff --git a/REPL/Main.lean b/REPL/Main.lean
 index a4b97c3..51f2d4a 100644
 --- a/REPL/Main.lean
 +++ b/REPL/Main.lean
 @@ -95,7 +95,7 @@ def recordProofSnapshot (proofState : ProofSnapshot) : M m Nat := do
    return id
- 
+
  def sorries (trees : List InfoTree) (env? : Option Environment) : M m (List Sorry) :=
 -  trees.flatMap InfoTree.sorries |>.filter (fun t => match t.2.1 with
 +  trees.bind InfoTree.sorries |>.filter (fun t => match t.2.1 with
@@ -118,7 +118,7 @@ index a4b97c3..51f2d4a 100644
        fun ⟨ctx, g, pos, endPos⟩ => do
 @@ -117,7 +117,7 @@ def ppTactic (ctx : ContextInfo) (stx : Syntax) : IO Format :=
      pure "<failed to pretty print>"
- 
+
  def tactics (trees : List InfoTree) : M m (List Tactic) :=
 -  trees.flatMap InfoTree.tactics |>.mapM
 +  trees.bind InfoTree.tactics |>.mapM
@@ -224,6 +224,20 @@ index 1e70935..6b26dd5 100644
 @@ -1 +1 @@
 -leanprover/lean4:v4.14.0
 +leanprover/lean4:v4.7.0-rc1
+diff --git a/test.sh b/test.sh
+index 070ce3d..4a24ae9 100755
+--- a/test.sh
++++ b/test.sh
+@@ -41,6 +41,6 @@ for infile in $IN_DIR/*.in; do
+
+ done
+
+-# Run the Mathlib tests
+-cp lean-toolchain test/Mathlib/
+-cd test/Mathlib/ && ./test.sh
++# Run the Mathlib tests - skipped as it takes too much time
++# cp lean-toolchain test/Mathlib/
++# cd test/Mathlib/ && ./test.sh
 diff --git a/test/Mathlib/lake-manifest.json b/test/Mathlib/lake-manifest.json
 index f312e5a..812c31d 100644
 --- a/test/Mathlib/lake-manifest.json
@@ -405,9 +419,9 @@ index cd3e590..2f3a097 100644
 @@ -1,4 +1,4 @@
 -{"cmd": "import Mathlib.Algebra.BigOperators.Group.Finset\nimport Mathlib.Data.Real.Basic\nimport Mathlib.Data.Complex.Basic\nimport Mathlib.Data.Nat.Log\nimport Mathlib.Data.Complex.Exponential\nimport Mathlib.NumberTheory.Divisors\nimport Mathlib.Data.ZMod.Defs\nimport Mathlib.Data.ZMod.Basic\nimport Mathlib.Topology.Basic\nimport Mathlib.Data.Nat.Digits\nimport Mathlib.Tactic.NormNum.GCD\nopen BigOperators\nopen Real\nopen Nat\nopen Topology"}
 +{"cmd": "import Mathlib.Algebra.BigOperators.Basic\nimport Mathlib.Data.Real.Basic\nimport Mathlib.Data.Complex.Basic\nimport Mathlib.Data.Nat.Log\nimport Mathlib.Data.Complex.Exponential\nimport Mathlib.NumberTheory.Divisors\nimport Mathlib.Data.ZMod.Defs\nimport Mathlib.Data.ZMod.Basic\nimport Mathlib.Topology.Basic\nimport Mathlib.Data.Nat.Digits\nimport Mathlib.Tactic.NormNum.GCD\nopen BigOperators\nopen Real\nopen Nat\nopen Topology"}
- 
+
  {"cmd": "theorem mathd_numbertheory_188 : Nat.gcd 180 168 = 12 := by norm_num", "env": 0}
- 
+
 diff --git a/test/Mathlib/test/H20231020.lean b/test/Mathlib/test/H20231020.lean
 index 670e12b..849e3c4 100644
 --- a/test/Mathlib/test/H20231020.lean
@@ -423,14 +437,14 @@ index 2efb1d8..f386cb7 100644
 --- a/test/Mathlib/test/H20231115.expected.out
 +++ b/test/Mathlib/test/H20231115.expected.out
 @@ -14,6 +14,6 @@
- 
+
  {"proofState": 1,
   "goals":
 - ["case zero\n⊢ 0 + 1 > 0",
 -  "case succ\nx : Nat\nhx : x + 1 > x\n⊢ x + 1 + 1 > x + 1"]}
 + ["case zero\n⊢ Nat.zero + 1 > Nat.zero",
 +  "case succ\nx : Nat\nhx : x + 1 > x\n⊢ Nat.succ x + 1 > Nat.succ x"]}
- 
+
 diff --git a/test/Mathlib/test/H20231115_2.expected.out b/test/Mathlib/test/H20231115_2.expected.out
 index 3c19b57..39d6142 100644
 --- a/test/Mathlib/test/H20231115_2.expected.out
@@ -460,7 +474,7 @@ index 3b72d40..45b397f 100644
 -   "unsolved goals\ncase zero\n⊢ 0 + 1 > 0\n\ncase succ\nx : Nat\nhx : x + 1 > x\n⊢ x + 1 + 1 > x + 1"}],
 +   "unsolved goals\ncase zero\n⊢ Nat.zero + 1 > Nat.zero\n\ncase succ\nx : Nat\nhx : x + 1 > x\n⊢ Nat.succ x + 1 > Nat.succ x"}],
   "env": 1}
- 
+
 diff --git a/test/Mathlib/test/H20231214.lean b/test/Mathlib/test/H20231214.lean
 index fc8ad1c..24f3f20 100644
 --- a/test/Mathlib/test/H20231214.lean
@@ -491,7 +505,7 @@ index 86cd1c6..1c1a057 100644
 -   "data": "Try this: exact Nat.one_pos"}],
 +   "data": "Try this: exact Nat.zero_lt_one"}],
   "goals": []}
- 
+
  {"sorries":
 diff --git a/test/Mathlib/test/exact.in b/test/Mathlib/test/exact.in
 index 72b4c50..5764c0f 100644
@@ -500,25 +514,25 @@ index 72b4c50..5764c0f 100644
 @@ -1,4 +1,4 @@
 -{"cmd": "import Mathlib"}
 +{"cmd": "import Mathlib\n\nset_option maxHeartbeats 500000"}
- 
+
  {"cmd": "theorem test : 0 < 1 := by sorry", "env": 0}
- 
+
 diff --git a/test/Mathlib/test/induction.expected.out b/test/Mathlib/test/induction.expected.out
 index 7ef34d3..8e19362 100644
 --- a/test/Mathlib/test/induction.expected.out
 +++ b/test/Mathlib/test/induction.expected.out
 @@ -14,14 +14,16 @@
- 
+
  {"proofState": 1,
   "goals":
 - ["case zero\n⊢ 0 = 0", "case succ\nn✝ : ℕ\na✝ : n✝ = n✝\n⊢ n✝ + 1 = n✝ + 1"]}
 + ["case zero\n⊢ Nat.zero = Nat.zero",
 +  "case succ\nn✝ : ℕ\nn_ih✝ : n✝ = n✝\n⊢ Nat.succ n✝ = Nat.succ n✝"]}
- 
+
  {"proofState": 2,
 - "goals": ["case succ\nn✝ : ℕ\na✝ : n✝ = n✝\n⊢ n✝ + 1 = n✝ + 1"]}
 + "goals": ["case succ\nn✝ : ℕ\nn_ih✝ : n✝ = n✝\n⊢ Nat.succ n✝ = Nat.succ n✝"]}
- 
+
  {"sorries":
 - [{"proofState": 3, "goal": "case zero\n⊢ 0 = 0"},
 -  {"proofState": 4, "goal": "case succ\nx : ℕ\na✝ : x = x\n⊢ x + 1 = x + 1"}],
@@ -527,7 +541,7 @@ index 7ef34d3..8e19362 100644
 +   "goal": "case succ\nx : ℕ\nn_ih✝ : x = x\n⊢ Nat.succ x = Nat.succ x"}],
   "proofState": 5,
   "goals": []}
- 
+
 diff --git a/test/all_tactics.expected.out b/test/all_tactics.expected.out
 index 6ec808c..5374db8 100644
 --- a/test/all_tactics.expected.out
@@ -540,7 +554,7 @@ index 6ec808c..5374db8 100644
 +   "goals": "t : Nat ⊢ Nat",
     "endPos": {"line": 1, "column": 39}}],
   "env": 0}
- 
+
 diff --git a/test/calc.expected.out b/test/calc.expected.out
 index 94f6a9f..fde8fee 100644
 --- a/test/calc.expected.out
@@ -604,14 +618,14 @@ index b4d885b..557d03b 100644
 +++ b/test/name_generator.expected.out
 @@ -24,13 +24,13 @@
   "goals": []}
- 
+
  {"traces":
 - ["[Meta.Tactic.simp.rewrite] gt_iff_lt:1000, x > 0 ==> 0 < x",
 + ["[Meta.Tactic.simp.rewrite] @gt_iff_lt:1000, x > 0 ==> 0 < x",
    "[Meta.Tactic.simp.rewrite] h0:1000, 0 < x ==> True"],
   "proofState": 6,
   "goals": []}
- 
+
  {"traces":
 - ["[Meta.Tactic.simp.rewrite] gt_iff_lt:1000, x > 0 ==> 0 < x",
 + ["[Meta.Tactic.simp.rewrite] @gt_iff_lt:1000, x > 0 ==> 0 < x",
@@ -633,7 +647,7 @@ index 5c89f5a..5be11b7 100644
 +   "endPos": {"line": 3, "column": 7},
 +   "data": "no goals to be solved"}],
   "env": 0}
- 
+
 diff --git a/test/trace_simp.expected.out b/test/trace_simp.expected.out
 index 2a85844..1f6fbeb 100644
 --- a/test/trace_simp.expected.out
@@ -645,17 +659,17 @@ index 2a85844..1f6fbeb 100644
 -   "[Meta.Tactic.simp.rewrite] f_def:1000, f ==> 37\n[Meta.Tactic.simp.rewrite] eq_self:1000, 37 = 37 ==> True"}],
 +   "[Meta.Tactic.simp.rewrite] f_def:1000, f ==> 37\n[Meta.Tactic.simp.rewrite] @eq_self:1000, 37 = 37 ==> True"}],
   "env": 3}
- 
+
  {"sorries":
 @@ -28,7 +28,7 @@
- 
+
  {"traces":
   ["[Meta.Tactic.simp.rewrite] f_def:1000, f ==> 37",
 -  "[Meta.Tactic.simp.rewrite] eq_self:1000, 37 = 37 ==> True"],
 +  "[Meta.Tactic.simp.rewrite] @eq_self:1000, 37 = 37 ==> True"],
   "proofState": 2,
   "goals": []}
- 
+
 diff --git a/test/variables.expected.out b/test/variables.expected.out
 index cd060cb..1504f9b 100644
 --- a/test/variables.expected.out
@@ -668,5 +682,5 @@ index cd060cb..1504f9b 100644
 -   "unused variable `y`\nnote: this linter can be disabled with `set_option linter.unusedVariables false`"}],
 +   "data": "unused variable `y` [linter.unusedVariables]"}],
   "env": 1}
- 
+
  {"sorries":

--- a/versions/v4.7.0-rc1.diff
+++ b/versions/v4.7.0-rc1.diff
@@ -11,7 +11,7 @@ index 9cc0914..a2bb150 100644
 +  let trees := s.infoState.trees.toList.drop commandState.infoState.trees.size
 +
 +  pure (s, msgs, trees)
-
+ 
  /--
  Process some text input, with or without an existing command state.
 diff --git a/REPL/JSON.lean b/REPL/JSON.lean
@@ -20,7 +20,7 @@ index d5c5ba2..b63c5ea 100644
 +++ b/REPL/JSON.lean
 @@ -83,7 +83,7 @@ structure Sorry where
  deriving FromJson
-
+ 
  instance : ToJson Sorry where
 -  toJson r := Json.mkObj <| .flatten [
 +  toJson r := Json.mkObj <| .join [
@@ -29,7 +29,7 @@ index d5c5ba2..b63c5ea 100644
      if r.pos.line ≠ 0 then [("pos", toJson r.pos)] else [],
 @@ -132,7 +132,7 @@ def Json.nonemptyList [ToJson α] (k : String) : List α → List (String × Jso
    | l  => [⟨k, toJson l⟩]
-
+ 
  instance : ToJson CommandResponse where
 -  toJson r := Json.mkObj <| .flatten [
 +  toJson r := Json.mkObj <| .join [
@@ -38,7 +38,7 @@ index d5c5ba2..b63c5ea 100644
      Json.nonemptyList "sorries" r.sorries,
 @@ -153,7 +153,7 @@ structure ProofStepResponse where
  deriving ToJson, FromJson
-
+ 
  instance : ToJson ProofStepResponse where
 -  toJson r := Json.mkObj <| .flatten [
 +  toJson r := Json.mkObj <| .join [
@@ -55,7 +55,7 @@ index 0b4be3c..61d4e76 100644
    let env ← importModules imports {} 0
 -  return (← env.replay (Std.HashMap.ofList map₂.toList), region)
 +  return (← env.replay (HashMap.ofList map₂.toList), region)
-
+ 
  end Lean.Environment
 diff --git a/REPL/Lean/InfoTree.lean b/REPL/Lean/InfoTree.lean
 index 7abf0b8..d3b28c1 100644
@@ -71,7 +71,7 @@ index 7abf0b8..d3b28c1 100644
 -      (children.toList.map (filter p m)).flatten
 +      (children.toList.map (filter p m)).join
    | .hole mvar => if m mvar then [.hole mvar] else []
-
+ 
  /-- Discard all nodes besides `.context` nodes and `TacticInfo` nodes. -/
 @@ -156,7 +156,7 @@ partial def findAllInfo (t : InfoTree) (ctx? : Option ContextInfo) (p : Info →
    | context ctx t => t.findAllInfo (ctx.mergeIntoOuter? ctx?) p
@@ -81,18 +81,18 @@ index 7abf0b8..d3b28c1 100644
 +    let rest := ts.toList.bind (fun t => t.findAllInfo ctx? p)
      info ++ rest
    | _ => []
-
+ 
 @@ -214,13 +214,13 @@ def sorries (t : InfoTree) : List (ContextInfo × SorryType × Position × Posit
-
+ 
  def tactics (t : InfoTree) : List (ContextInfo × Syntax × List MVarId × Position × Position × Array Name) :=
      -- HACK: creating a child ngen
--  t.findTacticNodes.map fun ⟨i, ctx⟩ =>
--    let range := stxRange ctx.fileMap i.stx
--    ( { ctx with mctx := i.mctxBefore, ngen := ctx.ngen.mkChild.1 },
--      i.stx,
--      i.goalsBefore,
--      range.fst,
--      range.snd,
+-  t.findTacticNodes.map fun ⟨i, ctx⟩ => 
+-    let range := stxRange ctx.fileMap i.stx 
+-    ( { ctx with mctx := i.mctxBefore, ngen := ctx.ngen.mkChild.1 }, 
+-      i.stx, 
+-      i.goalsBefore, 
+-      range.fst, 
+-      range.snd, 
 +  t.findTacticNodes.map fun ⟨i, ctx⟩ =>
 +    let range := stxRange ctx.fileMap i.stx
 +    ( { ctx with mctx := i.mctxBefore, ngen := ctx.ngen.mkChild.1 },
@@ -101,15 +101,15 @@ index 7abf0b8..d3b28c1 100644
 +      range.fst,
 +      range.snd,
        i.getUsedConstantsAsSet.toArray )
-
-
+ 
+ 
 diff --git a/REPL/Main.lean b/REPL/Main.lean
 index a4b97c3..51f2d4a 100644
 --- a/REPL/Main.lean
 +++ b/REPL/Main.lean
 @@ -95,7 +95,7 @@ def recordProofSnapshot (proofState : ProofSnapshot) : M m Nat := do
    return id
-
+ 
  def sorries (trees : List InfoTree) (env? : Option Environment) : M m (List Sorry) :=
 -  trees.flatMap InfoTree.sorries |>.filter (fun t => match t.2.1 with
 +  trees.bind InfoTree.sorries |>.filter (fun t => match t.2.1 with
@@ -118,7 +118,7 @@ index a4b97c3..51f2d4a 100644
        fun ⟨ctx, g, pos, endPos⟩ => do
 @@ -117,7 +117,7 @@ def ppTactic (ctx : ContextInfo) (stx : Syntax) : IO Format :=
      pure "<failed to pretty print>"
-
+ 
  def tactics (trees : List InfoTree) : M m (List Tactic) :=
 -  trees.flatMap InfoTree.tactics |>.mapM
 +  trees.bind InfoTree.tactics |>.mapM
@@ -419,9 +419,9 @@ index cd3e590..2f3a097 100644
 @@ -1,4 +1,4 @@
 -{"cmd": "import Mathlib.Algebra.BigOperators.Group.Finset\nimport Mathlib.Data.Real.Basic\nimport Mathlib.Data.Complex.Basic\nimport Mathlib.Data.Nat.Log\nimport Mathlib.Data.Complex.Exponential\nimport Mathlib.NumberTheory.Divisors\nimport Mathlib.Data.ZMod.Defs\nimport Mathlib.Data.ZMod.Basic\nimport Mathlib.Topology.Basic\nimport Mathlib.Data.Nat.Digits\nimport Mathlib.Tactic.NormNum.GCD\nopen BigOperators\nopen Real\nopen Nat\nopen Topology"}
 +{"cmd": "import Mathlib.Algebra.BigOperators.Basic\nimport Mathlib.Data.Real.Basic\nimport Mathlib.Data.Complex.Basic\nimport Mathlib.Data.Nat.Log\nimport Mathlib.Data.Complex.Exponential\nimport Mathlib.NumberTheory.Divisors\nimport Mathlib.Data.ZMod.Defs\nimport Mathlib.Data.ZMod.Basic\nimport Mathlib.Topology.Basic\nimport Mathlib.Data.Nat.Digits\nimport Mathlib.Tactic.NormNum.GCD\nopen BigOperators\nopen Real\nopen Nat\nopen Topology"}
-
+ 
  {"cmd": "theorem mathd_numbertheory_188 : Nat.gcd 180 168 = 12 := by norm_num", "env": 0}
-
+ 
 diff --git a/test/Mathlib/test/H20231020.lean b/test/Mathlib/test/H20231020.lean
 index 670e12b..849e3c4 100644
 --- a/test/Mathlib/test/H20231020.lean
@@ -437,14 +437,14 @@ index 2efb1d8..f386cb7 100644
 --- a/test/Mathlib/test/H20231115.expected.out
 +++ b/test/Mathlib/test/H20231115.expected.out
 @@ -14,6 +14,6 @@
-
+ 
  {"proofState": 1,
   "goals":
 - ["case zero\n⊢ 0 + 1 > 0",
 -  "case succ\nx : Nat\nhx : x + 1 > x\n⊢ x + 1 + 1 > x + 1"]}
 + ["case zero\n⊢ Nat.zero + 1 > Nat.zero",
 +  "case succ\nx : Nat\nhx : x + 1 > x\n⊢ Nat.succ x + 1 > Nat.succ x"]}
-
+ 
 diff --git a/test/Mathlib/test/H20231115_2.expected.out b/test/Mathlib/test/H20231115_2.expected.out
 index 3c19b57..39d6142 100644
 --- a/test/Mathlib/test/H20231115_2.expected.out
@@ -474,7 +474,7 @@ index 3b72d40..45b397f 100644
 -   "unsolved goals\ncase zero\n⊢ 0 + 1 > 0\n\ncase succ\nx : Nat\nhx : x + 1 > x\n⊢ x + 1 + 1 > x + 1"}],
 +   "unsolved goals\ncase zero\n⊢ Nat.zero + 1 > Nat.zero\n\ncase succ\nx : Nat\nhx : x + 1 > x\n⊢ Nat.succ x + 1 > Nat.succ x"}],
   "env": 1}
-
+ 
 diff --git a/test/Mathlib/test/H20231214.lean b/test/Mathlib/test/H20231214.lean
 index fc8ad1c..24f3f20 100644
 --- a/test/Mathlib/test/H20231214.lean
@@ -505,7 +505,7 @@ index 86cd1c6..1c1a057 100644
 -   "data": "Try this: exact Nat.one_pos"}],
 +   "data": "Try this: exact Nat.zero_lt_one"}],
   "goals": []}
-
+ 
  {"sorries":
 diff --git a/test/Mathlib/test/exact.in b/test/Mathlib/test/exact.in
 index 72b4c50..5764c0f 100644
@@ -514,25 +514,25 @@ index 72b4c50..5764c0f 100644
 @@ -1,4 +1,4 @@
 -{"cmd": "import Mathlib"}
 +{"cmd": "import Mathlib\n\nset_option maxHeartbeats 500000"}
-
+ 
  {"cmd": "theorem test : 0 < 1 := by sorry", "env": 0}
-
+ 
 diff --git a/test/Mathlib/test/induction.expected.out b/test/Mathlib/test/induction.expected.out
 index 7ef34d3..8e19362 100644
 --- a/test/Mathlib/test/induction.expected.out
 +++ b/test/Mathlib/test/induction.expected.out
 @@ -14,14 +14,16 @@
-
+ 
  {"proofState": 1,
   "goals":
 - ["case zero\n⊢ 0 = 0", "case succ\nn✝ : ℕ\na✝ : n✝ = n✝\n⊢ n✝ + 1 = n✝ + 1"]}
 + ["case zero\n⊢ Nat.zero = Nat.zero",
 +  "case succ\nn✝ : ℕ\nn_ih✝ : n✝ = n✝\n⊢ Nat.succ n✝ = Nat.succ n✝"]}
-
+ 
  {"proofState": 2,
 - "goals": ["case succ\nn✝ : ℕ\na✝ : n✝ = n✝\n⊢ n✝ + 1 = n✝ + 1"]}
 + "goals": ["case succ\nn✝ : ℕ\nn_ih✝ : n✝ = n✝\n⊢ Nat.succ n✝ = Nat.succ n✝"]}
-
+ 
  {"sorries":
 - [{"proofState": 3, "goal": "case zero\n⊢ 0 = 0"},
 -  {"proofState": 4, "goal": "case succ\nx : ℕ\na✝ : x = x\n⊢ x + 1 = x + 1"}],
@@ -541,7 +541,7 @@ index 7ef34d3..8e19362 100644
 +   "goal": "case succ\nx : ℕ\nn_ih✝ : x = x\n⊢ Nat.succ x = Nat.succ x"}],
   "proofState": 5,
   "goals": []}
-
+ 
 diff --git a/test/all_tactics.expected.out b/test/all_tactics.expected.out
 index 6ec808c..5374db8 100644
 --- a/test/all_tactics.expected.out
@@ -554,7 +554,7 @@ index 6ec808c..5374db8 100644
 +   "goals": "t : Nat ⊢ Nat",
     "endPos": {"line": 1, "column": 39}}],
   "env": 0}
-
+ 
 diff --git a/test/calc.expected.out b/test/calc.expected.out
 index 94f6a9f..fde8fee 100644
 --- a/test/calc.expected.out
@@ -618,14 +618,14 @@ index b4d885b..557d03b 100644
 +++ b/test/name_generator.expected.out
 @@ -24,13 +24,13 @@
   "goals": []}
-
+ 
  {"traces":
 - ["[Meta.Tactic.simp.rewrite] gt_iff_lt:1000, x > 0 ==> 0 < x",
 + ["[Meta.Tactic.simp.rewrite] @gt_iff_lt:1000, x > 0 ==> 0 < x",
    "[Meta.Tactic.simp.rewrite] h0:1000, 0 < x ==> True"],
   "proofState": 6,
   "goals": []}
-
+ 
  {"traces":
 - ["[Meta.Tactic.simp.rewrite] gt_iff_lt:1000, x > 0 ==> 0 < x",
 + ["[Meta.Tactic.simp.rewrite] @gt_iff_lt:1000, x > 0 ==> 0 < x",
@@ -647,7 +647,7 @@ index 5c89f5a..5be11b7 100644
 +   "endPos": {"line": 3, "column": 7},
 +   "data": "no goals to be solved"}],
   "env": 0}
-
+ 
 diff --git a/test/trace_simp.expected.out b/test/trace_simp.expected.out
 index 2a85844..1f6fbeb 100644
 --- a/test/trace_simp.expected.out
@@ -659,17 +659,17 @@ index 2a85844..1f6fbeb 100644
 -   "[Meta.Tactic.simp.rewrite] f_def:1000, f ==> 37\n[Meta.Tactic.simp.rewrite] eq_self:1000, 37 = 37 ==> True"}],
 +   "[Meta.Tactic.simp.rewrite] f_def:1000, f ==> 37\n[Meta.Tactic.simp.rewrite] @eq_self:1000, 37 = 37 ==> True"}],
   "env": 3}
-
+ 
  {"sorries":
 @@ -28,7 +28,7 @@
-
+ 
  {"traces":
   ["[Meta.Tactic.simp.rewrite] f_def:1000, f ==> 37",
 -  "[Meta.Tactic.simp.rewrite] eq_self:1000, 37 = 37 ==> True"],
 +  "[Meta.Tactic.simp.rewrite] @eq_self:1000, 37 = 37 ==> True"],
   "proofState": 2,
   "goals": []}
-
+ 
 diff --git a/test/variables.expected.out b/test/variables.expected.out
 index cd060cb..1504f9b 100644
 --- a/test/variables.expected.out
@@ -682,5 +682,5 @@ index cd060cb..1504f9b 100644
 -   "unused variable `y`\nnote: this linter can be disabled with `set_option linter.unusedVariables false`"}],
 +   "data": "unused variable `y` [linter.unusedVariables]"}],
   "env": 1}
-
+ 
  {"sorries":

--- a/versions/v4.7.0-rc2.diff
+++ b/versions/v4.7.0-rc2.diff
@@ -1,0 +1,672 @@
+diff --git a/REPL/Frontend.lean b/REPL/Frontend.lean
+index 9cc0914..a2bb150 100644
+--- a/REPL/Frontend.lean
++++ b/REPL/Frontend.lean
+@@ -20,7 +20,10 @@ def processCommandsWithInfoTrees
+     (commandState : Command.State) : IO (Command.State × List Message × List InfoTree) := do
+   let commandState := { commandState with infoState.enabled := true }
+   let s ← IO.processCommands inputCtx parserState commandState <&> Frontend.State.commandState
+-  pure (s, s.messages.toList, s.infoState.trees.toList)
++  let msgs := s.messages.toList.drop commandState.messages.toList.length
++  let trees := s.infoState.trees.toList.drop commandState.infoState.trees.size
++
++  pure (s, msgs, trees)
+ 
+ /--
+ Process some text input, with or without an existing command state.
+diff --git a/REPL/JSON.lean b/REPL/JSON.lean
+index d5c5ba2..b63c5ea 100644
+--- a/REPL/JSON.lean
++++ b/REPL/JSON.lean
+@@ -83,7 +83,7 @@ structure Sorry where
+ deriving FromJson
+ 
+ instance : ToJson Sorry where
+-  toJson r := Json.mkObj <| .flatten [
++  toJson r := Json.mkObj <| .join [
+     [("goal", r.goal)],
+     [("proofState", toJson r.proofState)],
+     if r.pos.line ≠ 0 then [("pos", toJson r.pos)] else [],
+@@ -132,7 +132,7 @@ def Json.nonemptyList [ToJson α] (k : String) : List α → List (String × Jso
+   | l  => [⟨k, toJson l⟩]
+ 
+ instance : ToJson CommandResponse where
+-  toJson r := Json.mkObj <| .flatten [
++  toJson r := Json.mkObj <| .join [
+     [("env", r.env)],
+     Json.nonemptyList "messages" r.messages,
+     Json.nonemptyList "sorries" r.sorries,
+@@ -153,7 +153,7 @@ structure ProofStepResponse where
+ deriving ToJson, FromJson
+ 
+ instance : ToJson ProofStepResponse where
+-  toJson r := Json.mkObj <| .flatten [
++  toJson r := Json.mkObj <| .join [
+     [("proofState", r.proofState)],
+     [("goals", toJson r.goals)],
+     Json.nonemptyList "messages" r.messages,
+diff --git a/REPL/Lean/Environment.lean b/REPL/Lean/Environment.lean
+index 0b4be3c..61d4e76 100644
+--- a/REPL/Lean/Environment.lean
++++ b/REPL/Lean/Environment.lean
+@@ -26,6 +26,6 @@ and then replace the new constants.
+ def unpickle (path : FilePath) : IO (Environment × CompactedRegion) := unsafe do
+   let ((imports, map₂), region) ← _root_.unpickle (Array Import × PHashMap Name ConstantInfo) path
+   let env ← importModules imports {} 0
+-  return (← env.replay (Std.HashMap.ofList map₂.toList), region)
++  return (← env.replay (HashMap.ofList map₂.toList), region)
+ 
+ end Lean.Environment
+diff --git a/REPL/Lean/InfoTree.lean b/REPL/Lean/InfoTree.lean
+index 7abf0b8..d3b28c1 100644
+--- a/REPL/Lean/InfoTree.lean
++++ b/REPL/Lean/InfoTree.lean
+@@ -131,9 +131,9 @@ partial def filter (p : Info → Bool) (m : MVarId → Bool := fun _ => false) :
+   | .context ctx tree => tree.filter p m |>.map (.context ctx)
+   | .node info children =>
+     if p info then
+-      [.node info (children.toList.map (filter p m)).flatten.toPArray']
++      [.node info (children.toList.map (filter p m)).join.toPArray']
+     else
+-      (children.toList.map (filter p m)).flatten
++      (children.toList.map (filter p m)).join
+   | .hole mvar => if m mvar then [.hole mvar] else []
+ 
+ /-- Discard all nodes besides `.context` nodes and `TacticInfo` nodes. -/
+@@ -156,7 +156,7 @@ partial def findAllInfo (t : InfoTree) (ctx? : Option ContextInfo) (p : Info →
+   | context ctx t => t.findAllInfo (ctx.mergeIntoOuter? ctx?) p
+   | node i ts  =>
+     let info := if p i then [(i, ctx?)] else []
+-    let rest := ts.toList.flatMap (fun t => t.findAllInfo ctx? p)
++    let rest := ts.toList.bind (fun t => t.findAllInfo ctx? p)
+     info ++ rest
+   | _ => []
+ 
+@@ -214,13 +214,13 @@ def sorries (t : InfoTree) : List (ContextInfo × SorryType × Position × Posit
+ 
+ def tactics (t : InfoTree) : List (ContextInfo × Syntax × List MVarId × Position × Position × Array Name) :=
+     -- HACK: creating a child ngen
+-  t.findTacticNodes.map fun ⟨i, ctx⟩ => 
+-    let range := stxRange ctx.fileMap i.stx 
+-    ( { ctx with mctx := i.mctxBefore, ngen := ctx.ngen.mkChild.1 }, 
+-      i.stx, 
+-      i.goalsBefore, 
+-      range.fst, 
+-      range.snd, 
++  t.findTacticNodes.map fun ⟨i, ctx⟩ =>
++    let range := stxRange ctx.fileMap i.stx
++    ( { ctx with mctx := i.mctxBefore, ngen := ctx.ngen.mkChild.1 },
++      i.stx,
++      i.goalsBefore,
++      range.fst,
++      range.snd,
+       i.getUsedConstantsAsSet.toArray )
+ 
+ 
+diff --git a/REPL/Main.lean b/REPL/Main.lean
+index a4b97c3..51f2d4a 100644
+--- a/REPL/Main.lean
++++ b/REPL/Main.lean
+@@ -95,7 +95,7 @@ def recordProofSnapshot (proofState : ProofSnapshot) : M m Nat := do
+   return id
+ 
+ def sorries (trees : List InfoTree) (env? : Option Environment) : M m (List Sorry) :=
+-  trees.flatMap InfoTree.sorries |>.filter (fun t => match t.2.1 with
++  trees.bind InfoTree.sorries |>.filter (fun t => match t.2.1 with
+     | .term _ none => false
+     | _ => true ) |>.mapM
+       fun ⟨ctx, g, pos, endPos⟩ => do
+@@ -117,7 +117,7 @@ def ppTactic (ctx : ContextInfo) (stx : Syntax) : IO Format :=
+     pure "<failed to pretty print>"
+ 
+ def tactics (trees : List InfoTree) : M m (List Tactic) :=
+-  trees.flatMap InfoTree.tactics |>.mapM
++  trees.bind InfoTree.tactics |>.mapM
+     fun ⟨ctx, stx, goals, pos, endPos, ns⟩ => do
+       let proofState := some (← ProofSnapshot.create ctx none none goals)
+       let goals := s!"{(← ctx.ppGoals goals)}".trim
+@@ -212,15 +212,13 @@ def runCommand (s : Command) : M IO (CommandResponse ⊕ Error) := do
+     cmdContext := (cmdSnapshot?.map fun c => c.cmdContext).getD
+       { fileName := "",
+         fileMap := default,
+-        tacticCache? := none,
+-        snap? := none,
+-        cancelTk? := none } }
++        tacticCache? := none } }
+   let env ← recordCommandSnapshot cmdSnapshot
+   let jsonTrees := match s.infotree with
+   | some "full" => trees
+-  | some "tactics" => trees.flatMap InfoTree.retainTacticInfo
+-  | some "original" => trees.flatMap InfoTree.retainTacticInfo |>.flatMap InfoTree.retainOriginal
+-  | some "substantive" => trees.flatMap InfoTree.retainTacticInfo |>.flatMap InfoTree.retainSubstantive
++  | some "tactics" => trees.bind InfoTree.retainTacticInfo
++  | some "original" => trees.bind InfoTree.retainTacticInfo |>.bind InfoTree.retainOriginal
++  | some "substantive" => trees.bind InfoTree.retainTacticInfo |>.bind InfoTree.retainSubstantive
+   | _ => []
+   let infotree ← if jsonTrees.isEmpty then
+     pure none
+diff --git a/REPL/Snapshots.lean b/REPL/Snapshots.lean
+index 1114c24..7462141 100644
+--- a/REPL/Snapshots.lean
++++ b/REPL/Snapshots.lean
+@@ -83,7 +83,7 @@ def unpickle (path : FilePath) : IO (CommandSnapshot × CompactedRegion) := unsa
+   let ((imports, map₂, cmdState, cmdContext), region) ←
+     _root_.unpickle (Array Import × PHashMap Name ConstantInfo × CompactableCommandSnapshot ×
+       Command.Context) path
+-  let env ← (← importModules imports {} 0).replay (Std.HashMap.ofList map₂.toList)
++  let env ← (← importModules imports {} 0).replay (HashMap.ofList map₂.toList)
+   let p' : CommandSnapshot :=
+   { cmdState := { cmdState with env }
+     cmdContext }
+@@ -284,9 +284,9 @@ def unpickle (path : FilePath) (cmd? : Option CommandSnapshot) :
+   let env ← match cmd? with
+   | none =>
+     enableInitializersExecution
+-    (← importModules imports {} 0).replay (Std.HashMap.ofList map₂.toList)
++    (← importModules imports {} 0).replay (HashMap.ofList map₂.toList)
+   | some cmd =>
+-    cmd.cmdState.env.replay (Std.HashMap.ofList map₂.toList)
++    cmd.cmdState.env.replay (HashMap.ofList map₂.toList)
+   let p' : ProofSnapshot :=
+   { coreState := { coreState with env }
+     coreContext
+diff --git a/lake-manifest.json b/lake-manifest.json
+index f80f175..7eec48b 100644
+--- a/lake-manifest.json
++++ b/lake-manifest.json
+@@ -1,4 +1,4 @@
+-{"version": "1.1.0",
++{"version": 7,
+  "packagesDir": ".lake/packages",
+  "packages": [],
+  "name": "REPL",
+diff --git a/lakefile.lean b/lakefile.lean
+new file mode 100644
+index 0000000..33dd0da
+--- /dev/null
++++ b/lakefile.lean
+@@ -0,0 +1,15 @@
++import Lake
++open Lake DSL
++
++package REPL {
++  -- add package configuration options here
++}
++
++lean_lib REPL {
++  -- add library configuration options here
++}
++
++@[default_target]
++lean_exe repl where
++  root := `REPL.Main
++  supportInterpreter := true
+diff --git a/lakefile.toml b/lakefile.toml
+deleted file mode 100644
+index 589e047..0000000
+--- a/lakefile.toml
++++ /dev/null
+@@ -1,10 +0,0 @@
+-name = "REPL"
+-defaultTargets = ["repl"]
+-
+-[[lean_lib]]
+-name = "REPL"
+-
+-[[lean_exe]]
+-name = "repl"
+-root = "REPL.Main"
+-supportInterpreter = true
+diff --git a/lean-toolchain b/lean-toolchain
+index 1e70935..e35881c 100644
+--- a/lean-toolchain
++++ b/lean-toolchain
+@@ -1 +1 @@
+-leanprover/lean4:v4.14.0
++leanprover/lean4:v4.7.0-rc2
+diff --git a/test/Mathlib/lake-manifest.json b/test/Mathlib/lake-manifest.json
+index f312e5a..61ee470 100644
+--- a/test/Mathlib/lake-manifest.json
++++ b/test/Mathlib/lake-manifest.json
+@@ -1,95 +1,68 @@
+-{"version": "1.1.0",
++{"version": 7,
+  "packagesDir": ".lake/packages",
+  "packages":
+- [{"url": "https://github.com/leanprover-community/mathlib4",
++ [{"url": "https://github.com/leanprover/std4",
+    "type": "git",
+    "subDir": null,
+-   "scope": "",
+-   "rev": "4bbdccd9c5f862bf90ff12f0a9e2c8be032b9a84",
+-   "name": "mathlib",
+-   "manifestFile": "lake-manifest.json",
+-   "inputRev": "v4.14.0",
+-   "inherited": false,
+-   "configFile": "lakefile.lean"},
+-  {"url": "https://github.com/leanprover-community/plausible",
+-   "type": "git",
+-   "subDir": null,
+-   "scope": "leanprover-community",
+-   "rev": "42dc02bdbc5d0c2f395718462a76c3d87318f7fa",
+-   "name": "plausible",
++   "rev": "ff9850c4726f6b9fb8d8e96980c3fcb2900be8bd",
++   "name": "std",
+    "manifestFile": "lake-manifest.json",
+    "inputRev": "main",
+    "inherited": true,
+-   "configFile": "lakefile.toml"},
+-  {"url": "https://github.com/leanprover-community/LeanSearchClient",
++   "configFile": "lakefile.lean"},
++  {"url": "https://github.com/leanprover-community/quote4",
+    "type": "git",
+    "subDir": null,
+-   "scope": "leanprover-community",
+-   "rev": "d7caecce0d0f003fd5e9cce9a61f1dd6ba83142b",
+-   "name": "LeanSearchClient",
++   "rev": "fd760831487e6835944e7eeed505522c9dd47563",
++   "name": "Qq",
+    "manifestFile": "lake-manifest.json",
+-   "inputRev": "main",
++   "inputRev": "master",
+    "inherited": true,
+-   "configFile": "lakefile.toml"},
+-  {"url": "https://github.com/leanprover-community/import-graph",
++   "configFile": "lakefile.lean"},
++  {"url": "https://github.com/leanprover-community/aesop",
+    "type": "git",
+    "subDir": null,
+-   "scope": "leanprover-community",
+-   "rev": "519e509a28864af5bed98033dd33b95cf08e9aa7",
+-   "name": "importGraph",
++   "rev": "056ca0fa8f5585539d0b940f532d9750c3a2270f",
++   "name": "aesop",
+    "manifestFile": "lake-manifest.json",
+-   "inputRev": "v4.14.0",
++   "inputRev": "master",
+    "inherited": true,
+-   "configFile": "lakefile.toml"},
++   "configFile": "lakefile.lean"},
+   {"url": "https://github.com/leanprover-community/ProofWidgets4",
+    "type": "git",
+    "subDir": null,
+-   "scope": "leanprover-community",
+-   "rev": "68280daef58803f68368eb2e53046dabcd270c9d",
++   "rev": "fb65c476595a453a9b8ffc4a1cea2db3a89b9cd8",
+    "name": "proofwidgets",
+    "manifestFile": "lake-manifest.json",
+-   "inputRev": "v0.0.47",
++   "inputRev": "v0.0.30",
+    "inherited": true,
+    "configFile": "lakefile.lean"},
+-  {"url": "https://github.com/leanprover-community/aesop",
+-   "type": "git",
+-   "subDir": null,
+-   "scope": "leanprover-community",
+-   "rev": "5a0ec8588855265ade536f35bcdcf0fb24fd6030",
+-   "name": "aesop",
+-   "manifestFile": "lake-manifest.json",
+-   "inputRev": "v4.14.0",
+-   "inherited": true,
+-   "configFile": "lakefile.toml"},
+-  {"url": "https://github.com/leanprover-community/quote4",
++  {"url": "https://github.com/leanprover/lean4-cli",
+    "type": "git",
+    "subDir": null,
+-   "scope": "leanprover-community",
+-   "rev": "303b23fbcea94ac4f96e590c1cad6618fd4f5f41",
+-   "name": "Qq",
++   "rev": "a751d21d4b68c999accb6fc5d960538af26ad5ec",
++   "name": "Cli",
+    "manifestFile": "lake-manifest.json",
+-   "inputRev": "master",
++   "inputRev": "main",
+    "inherited": true,
+    "configFile": "lakefile.lean"},
+-  {"url": "https://github.com/leanprover-community/batteries",
++  {"url": "https://github.com/leanprover-community/import-graph.git",
+    "type": "git",
+    "subDir": null,
+-   "scope": "leanprover-community",
+-   "rev": "8d6c853f11a5172efa0e96b9f2be1a83d861cdd9",
+-   "name": "batteries",
++   "rev": "64d082eeaad1a8e6bbb7c23b7a16b85a1715a02f",
++   "name": "importGraph",
+    "manifestFile": "lake-manifest.json",
+-   "inputRev": "v4.14.0",
++   "inputRev": "main",
+    "inherited": true,
+-   "configFile": "lakefile.toml"},
+-  {"url": "https://github.com/leanprover/lean4-cli",
++   "configFile": "lakefile.lean"},
++  {"url": "https://github.com/leanprover-community/mathlib4",
+    "type": "git",
+    "subDir": null,
+-   "scope": "leanprover",
+-   "rev": "726b3c9ad13acca724d4651f14afc4804a7b0e4d",
+-   "name": "Cli",
++   "rev": "59fdb6b04d7d16825a54483d550d9572ff473abf",
++   "name": "mathlib",
+    "manifestFile": "lake-manifest.json",
+-   "inputRev": "main",
+-   "inherited": true,
+-   "configFile": "lakefile.toml"}],
++   "inputRev": "v4.7.0-rc2",
++   "inherited": false,
++   "configFile": "lakefile.lean"}],
+  "name": "«repl-mathlib-tests»",
+  "lakeDir": ".lake"}
+diff --git a/test/Mathlib/lakefile.lean b/test/Mathlib/lakefile.lean
+new file mode 100644
+index 0000000..34c561d
+--- /dev/null
++++ b/test/Mathlib/lakefile.lean
+@@ -0,0 +1,11 @@
++import Lake
++open Lake DSL
++
++package «repl-mathlib-tests» where
++  -- add package configuration options here
++  require mathlib from git "https://github.com/leanprover-community/mathlib4" @ "v4.7.0-rc2"
++
++@[default_target]
++lean_lib «ReplMathlibTests» where
++  globs := #[.submodules `test]
++  -- add library configuration options here
+diff --git a/test/Mathlib/lakefile.toml b/test/Mathlib/lakefile.toml
+deleted file mode 100644
+index 6ff9631..0000000
+--- a/test/Mathlib/lakefile.toml
++++ /dev/null
+@@ -1,11 +0,0 @@
+-name = "«repl-mathlib-tests»"
+-defaultTargets = ["ReplMathlibTests"]
+-
+-[[require]]
+-name = "mathlib"
+-git = "https://github.com/leanprover-community/mathlib4"
+-rev = "v4.14.0"
+-
+-[[lean_lib]]
+-name = "ReplMathlibTests"
+-globs = ["test.+"]
+diff --git a/test/Mathlib/lean-toolchain b/test/Mathlib/lean-toolchain
+index 401bc14..e35881c 100644
+--- a/test/Mathlib/lean-toolchain
++++ b/test/Mathlib/lean-toolchain
+@@ -1 +1 @@
+-leanprover/lean4:v4.14.0
+\ No newline at end of file
++leanprover/lean4:v4.7.0-rc2
+diff --git a/test/Mathlib/test/H20231020.in b/test/Mathlib/test/H20231020.in
+index cd3e590..2f3a097 100644
+--- a/test/Mathlib/test/H20231020.in
++++ b/test/Mathlib/test/H20231020.in
+@@ -1,4 +1,4 @@
+-{"cmd": "import Mathlib.Algebra.BigOperators.Group.Finset\nimport Mathlib.Data.Real.Basic\nimport Mathlib.Data.Complex.Basic\nimport Mathlib.Data.Nat.Log\nimport Mathlib.Data.Complex.Exponential\nimport Mathlib.NumberTheory.Divisors\nimport Mathlib.Data.ZMod.Defs\nimport Mathlib.Data.ZMod.Basic\nimport Mathlib.Topology.Basic\nimport Mathlib.Data.Nat.Digits\nimport Mathlib.Tactic.NormNum.GCD\nopen BigOperators\nopen Real\nopen Nat\nopen Topology"}
++{"cmd": "import Mathlib.Algebra.BigOperators.Basic\nimport Mathlib.Data.Real.Basic\nimport Mathlib.Data.Complex.Basic\nimport Mathlib.Data.Nat.Log\nimport Mathlib.Data.Complex.Exponential\nimport Mathlib.NumberTheory.Divisors\nimport Mathlib.Data.ZMod.Defs\nimport Mathlib.Data.ZMod.Basic\nimport Mathlib.Topology.Basic\nimport Mathlib.Data.Nat.Digits\nimport Mathlib.Tactic.NormNum.GCD\nopen BigOperators\nopen Real\nopen Nat\nopen Topology"}
+ 
+ {"cmd": "theorem mathd_numbertheory_188 : Nat.gcd 180 168 = 12 := by norm_num", "env": 0}
+ 
+diff --git a/test/Mathlib/test/H20231020.lean b/test/Mathlib/test/H20231020.lean
+index 670e12b..849e3c4 100644
+--- a/test/Mathlib/test/H20231020.lean
++++ b/test/Mathlib/test/H20231020.lean
+@@ -1,4 +1,4 @@
+-import Mathlib.Algebra.BigOperators.Group.Finset
++import Mathlib.Algebra.BigOperators.Basic
+ import Mathlib.Data.Real.Basic
+ import Mathlib.Data.Complex.Basic
+ import Mathlib.Data.Nat.Log
+diff --git a/test/Mathlib/test/H20231115.expected.out b/test/Mathlib/test/H20231115.expected.out
+index 2efb1d8..f386cb7 100644
+--- a/test/Mathlib/test/H20231115.expected.out
++++ b/test/Mathlib/test/H20231115.expected.out
+@@ -14,6 +14,6 @@
+ 
+ {"proofState": 1,
+  "goals":
+- ["case zero\n⊢ 0 + 1 > 0",
+-  "case succ\nx : Nat\nhx : x + 1 > x\n⊢ x + 1 + 1 > x + 1"]}
++ ["case zero\n⊢ Nat.zero + 1 > Nat.zero",
++  "case succ\nx : Nat\nhx : x + 1 > x\n⊢ Nat.succ x + 1 > Nat.succ x"]}
+ 
+diff --git a/test/Mathlib/test/H20231115_2.expected.out b/test/Mathlib/test/H20231115_2.expected.out
+index 3c19b57..39d6142 100644
+--- a/test/Mathlib/test/H20231115_2.expected.out
++++ b/test/Mathlib/test/H20231115_2.expected.out
+@@ -3,11 +3,11 @@
+ {"sorries":
+  [{"proofState": 0,
+    "pos": {"line": 3, "column": 12},
+-   "goal": "case zero\n⊢ 0 + 1 > 0",
++   "goal": "case zero\n⊢ Nat.zero + 1 > Nat.zero",
+    "endPos": {"line": 3, "column": 17}},
+   {"proofState": 1,
+    "pos": {"line": 3, "column": 12},
+-   "goal": "case succ\nx : Nat\nhx : x + 1 > x\n⊢ x + 1 + 1 > x + 1",
++   "goal": "case succ\nx : Nat\nhx : x + 1 > x\n⊢ Nat.succ x + 1 > Nat.succ x",
+    "endPos": {"line": 3, "column": 17}}],
+  "messages":
+  [{"severity": "warning",
+diff --git a/test/Mathlib/test/H20231115_3.expected.out b/test/Mathlib/test/H20231115_3.expected.out
+index 3b72d40..45b397f 100644
+--- a/test/Mathlib/test/H20231115_3.expected.out
++++ b/test/Mathlib/test/H20231115_3.expected.out
+@@ -5,6 +5,6 @@
+    "pos": {"line": 1, "column": 33},
+    "endPos": {"line": 2, "column": 24},
+    "data":
+-   "unsolved goals\ncase zero\n⊢ 0 + 1 > 0\n\ncase succ\nx : Nat\nhx : x + 1 > x\n⊢ x + 1 + 1 > x + 1"}],
++   "unsolved goals\ncase zero\n⊢ Nat.zero + 1 > Nat.zero\n\ncase succ\nx : Nat\nhx : x + 1 > x\n⊢ Nat.succ x + 1 > Nat.succ x"}],
+  "env": 1}
+ 
+diff --git a/test/Mathlib/test/H20231214.lean b/test/Mathlib/test/H20231214.lean
+index fc8ad1c..24f3f20 100644
+--- a/test/Mathlib/test/H20231214.lean
++++ b/test/Mathlib/test/H20231214.lean
+@@ -12,14 +12,6 @@ but is expected to have type
+   p x = 6 / x * p x : Prop
+ ---
+ error: unsolved goals
+-case calc.step
+-p q : ℝ → ℝ
+-h₀ : ∀ (x : ℝ), p x = 2 - x ^ 2
+-h₁ : ∀ (x : ℝ), x ≠ 0 → q x = 6 / x
+-x : ℝ
+-⊢ 6 / 2 * 6 / x * (6 / x) = 6 / x
+----
+-error: unsolved goals
+ p q : ℝ → ℝ
+ h₀ : ∀ (x : ℝ), p x = 2 - x ^ 2
+ h₁ : ∀ (x : ℝ), x ≠ 0 → q x = 6 / x
+diff --git a/test/Mathlib/test/exact.expected.out b/test/Mathlib/test/exact.expected.out
+index 86cd1c6..1c1a057 100644
+--- a/test/Mathlib/test/exact.expected.out
++++ b/test/Mathlib/test/exact.expected.out
+@@ -17,7 +17,7 @@
+  [{"severity": "info",
+    "pos": {"line": 0, "column": 0},
+    "endPos": {"line": 0, "column": 0},
+-   "data": "Try this: exact Nat.one_pos"}],
++   "data": "Try this: exact Nat.zero_lt_one"}],
+  "goals": []}
+ 
+ {"sorries":
+diff --git a/test/Mathlib/test/exact.in b/test/Mathlib/test/exact.in
+index 72b4c50..5764c0f 100644
+--- a/test/Mathlib/test/exact.in
++++ b/test/Mathlib/test/exact.in
+@@ -1,4 +1,4 @@
+-{"cmd": "import Mathlib"}
++{"cmd": "import Mathlib\n\nset_option maxHeartbeats 500000"}
+ 
+ {"cmd": "theorem test : 0 < 1 := by sorry", "env": 0}
+ 
+diff --git a/test/Mathlib/test/induction.expected.out b/test/Mathlib/test/induction.expected.out
+index 7ef34d3..8e19362 100644
+--- a/test/Mathlib/test/induction.expected.out
++++ b/test/Mathlib/test/induction.expected.out
+@@ -14,14 +14,16 @@
+ 
+ {"proofState": 1,
+  "goals":
+- ["case zero\n⊢ 0 = 0", "case succ\nn✝ : ℕ\na✝ : n✝ = n✝\n⊢ n✝ + 1 = n✝ + 1"]}
++ ["case zero\n⊢ Nat.zero = Nat.zero",
++  "case succ\nn✝ : ℕ\nn_ih✝ : n✝ = n✝\n⊢ Nat.succ n✝ = Nat.succ n✝"]}
+ 
+ {"proofState": 2,
+- "goals": ["case succ\nn✝ : ℕ\na✝ : n✝ = n✝\n⊢ n✝ + 1 = n✝ + 1"]}
++ "goals": ["case succ\nn✝ : ℕ\nn_ih✝ : n✝ = n✝\n⊢ Nat.succ n✝ = Nat.succ n✝"]}
+ 
+ {"sorries":
+- [{"proofState": 3, "goal": "case zero\n⊢ 0 = 0"},
+-  {"proofState": 4, "goal": "case succ\nx : ℕ\na✝ : x = x\n⊢ x + 1 = x + 1"}],
++ [{"proofState": 3, "goal": "case zero\n⊢ Nat.zero = Nat.zero"},
++  {"proofState": 4,
++   "goal": "case succ\nx : ℕ\nn_ih✝ : x = x\n⊢ Nat.succ x = Nat.succ x"}],
+  "proofState": 5,
+  "goals": []}
+ 
+diff --git a/test/all_tactics.expected.out b/test/all_tactics.expected.out
+index 6ec808c..5374db8 100644
+--- a/test/all_tactics.expected.out
++++ b/test/all_tactics.expected.out
+@@ -9,7 +9,7 @@
+    "tactic": "exact t",
+    "proofState": 1,
+    "pos": {"line": 1, "column": 32},
+-   "goals": "t : Nat\n⊢ Nat",
++   "goals": "t : Nat ⊢ Nat",
+    "endPos": {"line": 1, "column": 39}}],
+  "env": 0}
+ 
+diff --git a/test/calc.expected.out b/test/calc.expected.out
+index 94f6a9f..fde8fee 100644
+--- a/test/calc.expected.out
++++ b/test/calc.expected.out
+@@ -1,35 +1,22 @@
+ {"tactics":
+  [{"usedConstants":
+-   ["Trans.trans",
+-    "sorryAx",
+-    "instOfNatNat",
+-    "instTransEq",
+-    "Nat",
+-    "OfNat.ofNat",
+-    "Bool.false",
+-    "Eq"],
++   ["Trans.trans", "instOfNatNat", "instTransEq", "Nat", "OfNat.ofNat", "Eq"],
+    "tactic": "calc\n  3 = 4 := by sorry\n  4 = 5 := by sorry",
+    "proofState": 2,
+    "pos": {"line": 1, "column": 22},
+    "goals": "⊢ 3 = 5",
+    "endPos": {"line": 3, "column": 19}},
+-  {"usedConstants": [],
+-   "tactic": "\n  3 = 4 := by sorry\n  4 = 5 := by sorry",
+-   "proofState": 3,
+-   "pos": {"line": 2, "column": 2},
+-   "goals": "no goals",
+-   "endPos": {"line": 3, "column": 19}},
+   {"usedConstants":
+    ["sorryAx", "instOfNatNat", "Nat", "OfNat.ofNat", "Bool.false", "Eq"],
+    "tactic": "sorry",
+-   "proofState": 4,
++   "proofState": 3,
+    "pos": {"line": 2, "column": 14},
+    "goals": "⊢ 3 = 4",
+    "endPos": {"line": 2, "column": 19}},
+   {"usedConstants":
+    ["sorryAx", "instOfNatNat", "Nat", "OfNat.ofNat", "Bool.false", "Eq"],
+    "tactic": "sorry",
+-   "proofState": 5,
++   "proofState": 4,
+    "pos": {"line": 3, "column": 14},
+    "goals": "⊢ 4 = 5",
+    "endPos": {"line": 3, "column": 19}}],
+diff --git a/test/infotree.expected.out b/test/infotree.expected.out
+index cb76c20..236e1ba 100644
+--- a/test/infotree.expected.out
++++ b/test/infotree.expected.out
+@@ -2,8 +2,7 @@
+  [{"severity": "warning",
+    "pos": {"line": 1, "column": 7},
+    "endPos": {"line": 1, "column": 8},
+-   "data":
+-   "unused variable `h`\nnote: this linter can be disabled with `set_option linter.unusedVariables false`"}],
++   "data": "unused variable `h` [linter.unusedVariables]"}],
+  "infotree":
+  [{"node":
+    {"stx":
+diff --git a/test/name_generator.expected.out b/test/name_generator.expected.out
+index b4d885b..557d03b 100644
+--- a/test/name_generator.expected.out
++++ b/test/name_generator.expected.out
+@@ -24,13 +24,13 @@
+  "goals": []}
+ 
+ {"traces":
+- ["[Meta.Tactic.simp.rewrite] gt_iff_lt:1000, x > 0 ==> 0 < x",
++ ["[Meta.Tactic.simp.rewrite] @gt_iff_lt:1000, x > 0 ==> 0 < x",
+   "[Meta.Tactic.simp.rewrite] h0:1000, 0 < x ==> True"],
+  "proofState": 6,
+  "goals": []}
+ 
+ {"traces":
+- ["[Meta.Tactic.simp.rewrite] gt_iff_lt:1000, x > 0 ==> 0 < x",
++ ["[Meta.Tactic.simp.rewrite] @gt_iff_lt:1000, x > 0 ==> 0 < x",
+   "[Meta.Tactic.simp.rewrite] h0:1000, 0 < x ==> True"],
+  "proofState": 7,
+  "goals": []}
+diff --git a/test/no_goal_sorry.expected.out b/test/no_goal_sorry.expected.out
+index 5c89f5a..5be11b7 100644
+--- a/test/no_goal_sorry.expected.out
++++ b/test/no_goal_sorry.expected.out
+@@ -4,8 +4,8 @@
+    "endPos": {"line": 2, "column": 18},
+    "data": "type expected, got\n  (set Nat : ?m.8 PUnit)"},
+   {"severity": "error",
+-   "pos": {"line": 2, "column": 22},
+-   "endPos": {"line": 2, "column": 24},
+-   "data": "Case tag 'body' not found.\n\nThere are no cases to select."}],
++   "pos": {"line": 3, "column": 2},
++   "endPos": {"line": 3, "column": 7},
++   "data": "no goals to be solved"}],
+  "env": 0}
+ 
+diff --git a/test/trace_simp.expected.out b/test/trace_simp.expected.out
+index 2a85844..1f6fbeb 100644
+--- a/test/trace_simp.expected.out
++++ b/test/trace_simp.expected.out
+@@ -9,7 +9,7 @@
+    "pos": {"line": 1, "column": 23},
+    "endPos": {"line": 1, "column": 27},
+    "data":
+-   "[Meta.Tactic.simp.rewrite] f_def:1000, f ==> 37\n[Meta.Tactic.simp.rewrite] eq_self:1000, 37 = 37 ==> True"}],
++   "[Meta.Tactic.simp.rewrite] f_def:1000, f ==> 37\n[Meta.Tactic.simp.rewrite] @eq_self:1000, 37 = 37 ==> True"}],
+  "env": 3}
+ 
+ {"sorries":
+@@ -28,7 +28,7 @@
+ 
+ {"traces":
+  ["[Meta.Tactic.simp.rewrite] f_def:1000, f ==> 37",
+-  "[Meta.Tactic.simp.rewrite] eq_self:1000, 37 = 37 ==> True"],
++  "[Meta.Tactic.simp.rewrite] @eq_self:1000, 37 = 37 ==> True"],
+  "proofState": 2,
+  "goals": []}
+ 
+diff --git a/test/variables.expected.out b/test/variables.expected.out
+index cd060cb..1504f9b 100644
+--- a/test/variables.expected.out
++++ b/test/variables.expected.out
+@@ -4,8 +4,7 @@
+  [{"severity": "warning",
+    "pos": {"line": 1, "column": 12},
+    "endPos": {"line": 1, "column": 13},
+-   "data":
+-   "unused variable `y`\nnote: this linter can be disabled with `set_option linter.unusedVariables false`"}],
++   "data": "unused variable `y` [linter.unusedVariables]"}],
+  "env": 1}
+ 
+ {"sorries":

--- a/versions/v4.7.0.diff
+++ b/versions/v4.7.0.diff
@@ -1,0 +1,672 @@
+diff --git a/REPL/Frontend.lean b/REPL/Frontend.lean
+index 9cc0914..a2bb150 100644
+--- a/REPL/Frontend.lean
++++ b/REPL/Frontend.lean
+@@ -20,7 +20,10 @@ def processCommandsWithInfoTrees
+     (commandState : Command.State) : IO (Command.State × List Message × List InfoTree) := do
+   let commandState := { commandState with infoState.enabled := true }
+   let s ← IO.processCommands inputCtx parserState commandState <&> Frontend.State.commandState
+-  pure (s, s.messages.toList, s.infoState.trees.toList)
++  let msgs := s.messages.toList.drop commandState.messages.toList.length
++  let trees := s.infoState.trees.toList.drop commandState.infoState.trees.size
++
++  pure (s, msgs, trees)
+ 
+ /--
+ Process some text input, with or without an existing command state.
+diff --git a/REPL/JSON.lean b/REPL/JSON.lean
+index d5c5ba2..b63c5ea 100644
+--- a/REPL/JSON.lean
++++ b/REPL/JSON.lean
+@@ -83,7 +83,7 @@ structure Sorry where
+ deriving FromJson
+ 
+ instance : ToJson Sorry where
+-  toJson r := Json.mkObj <| .flatten [
++  toJson r := Json.mkObj <| .join [
+     [("goal", r.goal)],
+     [("proofState", toJson r.proofState)],
+     if r.pos.line ≠ 0 then [("pos", toJson r.pos)] else [],
+@@ -132,7 +132,7 @@ def Json.nonemptyList [ToJson α] (k : String) : List α → List (String × Jso
+   | l  => [⟨k, toJson l⟩]
+ 
+ instance : ToJson CommandResponse where
+-  toJson r := Json.mkObj <| .flatten [
++  toJson r := Json.mkObj <| .join [
+     [("env", r.env)],
+     Json.nonemptyList "messages" r.messages,
+     Json.nonemptyList "sorries" r.sorries,
+@@ -153,7 +153,7 @@ structure ProofStepResponse where
+ deriving ToJson, FromJson
+ 
+ instance : ToJson ProofStepResponse where
+-  toJson r := Json.mkObj <| .flatten [
++  toJson r := Json.mkObj <| .join [
+     [("proofState", r.proofState)],
+     [("goals", toJson r.goals)],
+     Json.nonemptyList "messages" r.messages,
+diff --git a/REPL/Lean/Environment.lean b/REPL/Lean/Environment.lean
+index 0b4be3c..61d4e76 100644
+--- a/REPL/Lean/Environment.lean
++++ b/REPL/Lean/Environment.lean
+@@ -26,6 +26,6 @@ and then replace the new constants.
+ def unpickle (path : FilePath) : IO (Environment × CompactedRegion) := unsafe do
+   let ((imports, map₂), region) ← _root_.unpickle (Array Import × PHashMap Name ConstantInfo) path
+   let env ← importModules imports {} 0
+-  return (← env.replay (Std.HashMap.ofList map₂.toList), region)
++  return (← env.replay (HashMap.ofList map₂.toList), region)
+ 
+ end Lean.Environment
+diff --git a/REPL/Lean/InfoTree.lean b/REPL/Lean/InfoTree.lean
+index 7abf0b8..d3b28c1 100644
+--- a/REPL/Lean/InfoTree.lean
++++ b/REPL/Lean/InfoTree.lean
+@@ -131,9 +131,9 @@ partial def filter (p : Info → Bool) (m : MVarId → Bool := fun _ => false) :
+   | .context ctx tree => tree.filter p m |>.map (.context ctx)
+   | .node info children =>
+     if p info then
+-      [.node info (children.toList.map (filter p m)).flatten.toPArray']
++      [.node info (children.toList.map (filter p m)).join.toPArray']
+     else
+-      (children.toList.map (filter p m)).flatten
++      (children.toList.map (filter p m)).join
+   | .hole mvar => if m mvar then [.hole mvar] else []
+ 
+ /-- Discard all nodes besides `.context` nodes and `TacticInfo` nodes. -/
+@@ -156,7 +156,7 @@ partial def findAllInfo (t : InfoTree) (ctx? : Option ContextInfo) (p : Info →
+   | context ctx t => t.findAllInfo (ctx.mergeIntoOuter? ctx?) p
+   | node i ts  =>
+     let info := if p i then [(i, ctx?)] else []
+-    let rest := ts.toList.flatMap (fun t => t.findAllInfo ctx? p)
++    let rest := ts.toList.bind (fun t => t.findAllInfo ctx? p)
+     info ++ rest
+   | _ => []
+ 
+@@ -214,13 +214,13 @@ def sorries (t : InfoTree) : List (ContextInfo × SorryType × Position × Posit
+ 
+ def tactics (t : InfoTree) : List (ContextInfo × Syntax × List MVarId × Position × Position × Array Name) :=
+     -- HACK: creating a child ngen
+-  t.findTacticNodes.map fun ⟨i, ctx⟩ => 
+-    let range := stxRange ctx.fileMap i.stx 
+-    ( { ctx with mctx := i.mctxBefore, ngen := ctx.ngen.mkChild.1 }, 
+-      i.stx, 
+-      i.goalsBefore, 
+-      range.fst, 
+-      range.snd, 
++  t.findTacticNodes.map fun ⟨i, ctx⟩ =>
++    let range := stxRange ctx.fileMap i.stx
++    ( { ctx with mctx := i.mctxBefore, ngen := ctx.ngen.mkChild.1 },
++      i.stx,
++      i.goalsBefore,
++      range.fst,
++      range.snd,
+       i.getUsedConstantsAsSet.toArray )
+ 
+ 
+diff --git a/REPL/Main.lean b/REPL/Main.lean
+index a4b97c3..51f2d4a 100644
+--- a/REPL/Main.lean
++++ b/REPL/Main.lean
+@@ -95,7 +95,7 @@ def recordProofSnapshot (proofState : ProofSnapshot) : M m Nat := do
+   return id
+ 
+ def sorries (trees : List InfoTree) (env? : Option Environment) : M m (List Sorry) :=
+-  trees.flatMap InfoTree.sorries |>.filter (fun t => match t.2.1 with
++  trees.bind InfoTree.sorries |>.filter (fun t => match t.2.1 with
+     | .term _ none => false
+     | _ => true ) |>.mapM
+       fun ⟨ctx, g, pos, endPos⟩ => do
+@@ -117,7 +117,7 @@ def ppTactic (ctx : ContextInfo) (stx : Syntax) : IO Format :=
+     pure "<failed to pretty print>"
+ 
+ def tactics (trees : List InfoTree) : M m (List Tactic) :=
+-  trees.flatMap InfoTree.tactics |>.mapM
++  trees.bind InfoTree.tactics |>.mapM
+     fun ⟨ctx, stx, goals, pos, endPos, ns⟩ => do
+       let proofState := some (← ProofSnapshot.create ctx none none goals)
+       let goals := s!"{(← ctx.ppGoals goals)}".trim
+@@ -212,15 +212,13 @@ def runCommand (s : Command) : M IO (CommandResponse ⊕ Error) := do
+     cmdContext := (cmdSnapshot?.map fun c => c.cmdContext).getD
+       { fileName := "",
+         fileMap := default,
+-        tacticCache? := none,
+-        snap? := none,
+-        cancelTk? := none } }
++        tacticCache? := none } }
+   let env ← recordCommandSnapshot cmdSnapshot
+   let jsonTrees := match s.infotree with
+   | some "full" => trees
+-  | some "tactics" => trees.flatMap InfoTree.retainTacticInfo
+-  | some "original" => trees.flatMap InfoTree.retainTacticInfo |>.flatMap InfoTree.retainOriginal
+-  | some "substantive" => trees.flatMap InfoTree.retainTacticInfo |>.flatMap InfoTree.retainSubstantive
++  | some "tactics" => trees.bind InfoTree.retainTacticInfo
++  | some "original" => trees.bind InfoTree.retainTacticInfo |>.bind InfoTree.retainOriginal
++  | some "substantive" => trees.bind InfoTree.retainTacticInfo |>.bind InfoTree.retainSubstantive
+   | _ => []
+   let infotree ← if jsonTrees.isEmpty then
+     pure none
+diff --git a/REPL/Snapshots.lean b/REPL/Snapshots.lean
+index 1114c24..7462141 100644
+--- a/REPL/Snapshots.lean
++++ b/REPL/Snapshots.lean
+@@ -83,7 +83,7 @@ def unpickle (path : FilePath) : IO (CommandSnapshot × CompactedRegion) := unsa
+   let ((imports, map₂, cmdState, cmdContext), region) ←
+     _root_.unpickle (Array Import × PHashMap Name ConstantInfo × CompactableCommandSnapshot ×
+       Command.Context) path
+-  let env ← (← importModules imports {} 0).replay (Std.HashMap.ofList map₂.toList)
++  let env ← (← importModules imports {} 0).replay (HashMap.ofList map₂.toList)
+   let p' : CommandSnapshot :=
+   { cmdState := { cmdState with env }
+     cmdContext }
+@@ -284,9 +284,9 @@ def unpickle (path : FilePath) (cmd? : Option CommandSnapshot) :
+   let env ← match cmd? with
+   | none =>
+     enableInitializersExecution
+-    (← importModules imports {} 0).replay (Std.HashMap.ofList map₂.toList)
++    (← importModules imports {} 0).replay (HashMap.ofList map₂.toList)
+   | some cmd =>
+-    cmd.cmdState.env.replay (Std.HashMap.ofList map₂.toList)
++    cmd.cmdState.env.replay (HashMap.ofList map₂.toList)
+   let p' : ProofSnapshot :=
+   { coreState := { coreState with env }
+     coreContext
+diff --git a/lake-manifest.json b/lake-manifest.json
+index f80f175..7eec48b 100644
+--- a/lake-manifest.json
++++ b/lake-manifest.json
+@@ -1,4 +1,4 @@
+-{"version": "1.1.0",
++{"version": 7,
+  "packagesDir": ".lake/packages",
+  "packages": [],
+  "name": "REPL",
+diff --git a/lakefile.lean b/lakefile.lean
+new file mode 100644
+index 0000000..33dd0da
+--- /dev/null
++++ b/lakefile.lean
+@@ -0,0 +1,15 @@
++import Lake
++open Lake DSL
++
++package REPL {
++  -- add package configuration options here
++}
++
++lean_lib REPL {
++  -- add library configuration options here
++}
++
++@[default_target]
++lean_exe repl where
++  root := `REPL.Main
++  supportInterpreter := true
+diff --git a/lakefile.toml b/lakefile.toml
+deleted file mode 100644
+index 589e047..0000000
+--- a/lakefile.toml
++++ /dev/null
+@@ -1,10 +0,0 @@
+-name = "REPL"
+-defaultTargets = ["repl"]
+-
+-[[lean_lib]]
+-name = "REPL"
+-
+-[[lean_exe]]
+-name = "repl"
+-root = "REPL.Main"
+-supportInterpreter = true
+diff --git a/lean-toolchain b/lean-toolchain
+index 1e70935..9ad3040 100644
+--- a/lean-toolchain
++++ b/lean-toolchain
+@@ -1 +1 @@
+-leanprover/lean4:v4.14.0
++leanprover/lean4:v4.7.0
+diff --git a/test/Mathlib/lake-manifest.json b/test/Mathlib/lake-manifest.json
+index f312e5a..52f878d 100644
+--- a/test/Mathlib/lake-manifest.json
++++ b/test/Mathlib/lake-manifest.json
+@@ -1,95 +1,68 @@
+-{"version": "1.1.0",
++{"version": 7,
+  "packagesDir": ".lake/packages",
+  "packages":
+- [{"url": "https://github.com/leanprover-community/mathlib4",
++ [{"url": "https://github.com/leanprover/std4",
+    "type": "git",
+    "subDir": null,
+-   "scope": "",
+-   "rev": "4bbdccd9c5f862bf90ff12f0a9e2c8be032b9a84",
+-   "name": "mathlib",
+-   "manifestFile": "lake-manifest.json",
+-   "inputRev": "v4.14.0",
+-   "inherited": false,
+-   "configFile": "lakefile.lean"},
+-  {"url": "https://github.com/leanprover-community/plausible",
+-   "type": "git",
+-   "subDir": null,
+-   "scope": "leanprover-community",
+-   "rev": "42dc02bdbc5d0c2f395718462a76c3d87318f7fa",
+-   "name": "plausible",
++   "rev": "32983874c1b897d78f20d620fe92fc8fd3f06c3a",
++   "name": "std",
+    "manifestFile": "lake-manifest.json",
+    "inputRev": "main",
+    "inherited": true,
+-   "configFile": "lakefile.toml"},
+-  {"url": "https://github.com/leanprover-community/LeanSearchClient",
++   "configFile": "lakefile.lean"},
++  {"url": "https://github.com/leanprover-community/quote4",
+    "type": "git",
+    "subDir": null,
+-   "scope": "leanprover-community",
+-   "rev": "d7caecce0d0f003fd5e9cce9a61f1dd6ba83142b",
+-   "name": "LeanSearchClient",
++   "rev": "64365c656d5e1bffa127d2a1795f471529ee0178",
++   "name": "Qq",
+    "manifestFile": "lake-manifest.json",
+-   "inputRev": "main",
++   "inputRev": "master",
+    "inherited": true,
+-   "configFile": "lakefile.toml"},
+-  {"url": "https://github.com/leanprover-community/import-graph",
++   "configFile": "lakefile.lean"},
++  {"url": "https://github.com/leanprover-community/aesop",
+    "type": "git",
+    "subDir": null,
+-   "scope": "leanprover-community",
+-   "rev": "519e509a28864af5bed98033dd33b95cf08e9aa7",
+-   "name": "importGraph",
++   "rev": "5fefb40a7c9038a7150e7edd92e43b1b94c49e79",
++   "name": "aesop",
+    "manifestFile": "lake-manifest.json",
+-   "inputRev": "v4.14.0",
++   "inputRev": "master",
+    "inherited": true,
+-   "configFile": "lakefile.toml"},
++   "configFile": "lakefile.lean"},
+   {"url": "https://github.com/leanprover-community/ProofWidgets4",
+    "type": "git",
+    "subDir": null,
+-   "scope": "leanprover-community",
+-   "rev": "68280daef58803f68368eb2e53046dabcd270c9d",
++   "rev": "fb65c476595a453a9b8ffc4a1cea2db3a89b9cd8",
+    "name": "proofwidgets",
+    "manifestFile": "lake-manifest.json",
+-   "inputRev": "v0.0.47",
++   "inputRev": "v0.0.30",
+    "inherited": true,
+    "configFile": "lakefile.lean"},
+-  {"url": "https://github.com/leanprover-community/aesop",
+-   "type": "git",
+-   "subDir": null,
+-   "scope": "leanprover-community",
+-   "rev": "5a0ec8588855265ade536f35bcdcf0fb24fd6030",
+-   "name": "aesop",
+-   "manifestFile": "lake-manifest.json",
+-   "inputRev": "v4.14.0",
+-   "inherited": true,
+-   "configFile": "lakefile.toml"},
+-  {"url": "https://github.com/leanprover-community/quote4",
++  {"url": "https://github.com/leanprover/lean4-cli",
+    "type": "git",
+    "subDir": null,
+-   "scope": "leanprover-community",
+-   "rev": "303b23fbcea94ac4f96e590c1cad6618fd4f5f41",
+-   "name": "Qq",
++   "rev": "be8fa79a28b8b6897dce0713ef50e89c4a0f6ef5",
++   "name": "Cli",
+    "manifestFile": "lake-manifest.json",
+-   "inputRev": "master",
++   "inputRev": "main",
+    "inherited": true,
+    "configFile": "lakefile.lean"},
+-  {"url": "https://github.com/leanprover-community/batteries",
++  {"url": "https://github.com/leanprover-community/import-graph.git",
+    "type": "git",
+    "subDir": null,
+-   "scope": "leanprover-community",
+-   "rev": "8d6c853f11a5172efa0e96b9f2be1a83d861cdd9",
+-   "name": "batteries",
++   "rev": "61a79185b6582573d23bf7e17f2137cd49e7e662",
++   "name": "importGraph",
+    "manifestFile": "lake-manifest.json",
+-   "inputRev": "v4.14.0",
++   "inputRev": "main",
+    "inherited": true,
+-   "configFile": "lakefile.toml"},
+-  {"url": "https://github.com/leanprover/lean4-cli",
++   "configFile": "lakefile.lean"},
++  {"url": "https://github.com/leanprover-community/mathlib4",
+    "type": "git",
+    "subDir": null,
+-   "scope": "leanprover",
+-   "rev": "726b3c9ad13acca724d4651f14afc4804a7b0e4d",
+-   "name": "Cli",
++   "rev": "a45ae63747140c1b2cbad9d46f518015c047047a",
++   "name": "mathlib",
+    "manifestFile": "lake-manifest.json",
+-   "inputRev": "main",
+-   "inherited": true,
+-   "configFile": "lakefile.toml"}],
++   "inputRev": "v4.7.0",
++   "inherited": false,
++   "configFile": "lakefile.lean"}],
+  "name": "«repl-mathlib-tests»",
+  "lakeDir": ".lake"}
+diff --git a/test/Mathlib/lakefile.lean b/test/Mathlib/lakefile.lean
+new file mode 100644
+index 0000000..23a10ca
+--- /dev/null
++++ b/test/Mathlib/lakefile.lean
+@@ -0,0 +1,11 @@
++import Lake
++open Lake DSL
++
++package «repl-mathlib-tests» where
++  -- add package configuration options here
++  require mathlib from git "https://github.com/leanprover-community/mathlib4" @ "v4.7.0"
++
++@[default_target]
++lean_lib «ReplMathlibTests» where
++  globs := #[.submodules `test]
++  -- add library configuration options here
+diff --git a/test/Mathlib/lakefile.toml b/test/Mathlib/lakefile.toml
+deleted file mode 100644
+index 6ff9631..0000000
+--- a/test/Mathlib/lakefile.toml
++++ /dev/null
+@@ -1,11 +0,0 @@
+-name = "«repl-mathlib-tests»"
+-defaultTargets = ["ReplMathlibTests"]
+-
+-[[require]]
+-name = "mathlib"
+-git = "https://github.com/leanprover-community/mathlib4"
+-rev = "v4.14.0"
+-
+-[[lean_lib]]
+-name = "ReplMathlibTests"
+-globs = ["test.+"]
+diff --git a/test/Mathlib/lean-toolchain b/test/Mathlib/lean-toolchain
+index 401bc14..9ad3040 100644
+--- a/test/Mathlib/lean-toolchain
++++ b/test/Mathlib/lean-toolchain
+@@ -1 +1 @@
+-leanprover/lean4:v4.14.0
+\ No newline at end of file
++leanprover/lean4:v4.7.0
+diff --git a/test/Mathlib/test/H20231020.in b/test/Mathlib/test/H20231020.in
+index cd3e590..2f3a097 100644
+--- a/test/Mathlib/test/H20231020.in
++++ b/test/Mathlib/test/H20231020.in
+@@ -1,4 +1,4 @@
+-{"cmd": "import Mathlib.Algebra.BigOperators.Group.Finset\nimport Mathlib.Data.Real.Basic\nimport Mathlib.Data.Complex.Basic\nimport Mathlib.Data.Nat.Log\nimport Mathlib.Data.Complex.Exponential\nimport Mathlib.NumberTheory.Divisors\nimport Mathlib.Data.ZMod.Defs\nimport Mathlib.Data.ZMod.Basic\nimport Mathlib.Topology.Basic\nimport Mathlib.Data.Nat.Digits\nimport Mathlib.Tactic.NormNum.GCD\nopen BigOperators\nopen Real\nopen Nat\nopen Topology"}
++{"cmd": "import Mathlib.Algebra.BigOperators.Basic\nimport Mathlib.Data.Real.Basic\nimport Mathlib.Data.Complex.Basic\nimport Mathlib.Data.Nat.Log\nimport Mathlib.Data.Complex.Exponential\nimport Mathlib.NumberTheory.Divisors\nimport Mathlib.Data.ZMod.Defs\nimport Mathlib.Data.ZMod.Basic\nimport Mathlib.Topology.Basic\nimport Mathlib.Data.Nat.Digits\nimport Mathlib.Tactic.NormNum.GCD\nopen BigOperators\nopen Real\nopen Nat\nopen Topology"}
+ 
+ {"cmd": "theorem mathd_numbertheory_188 : Nat.gcd 180 168 = 12 := by norm_num", "env": 0}
+ 
+diff --git a/test/Mathlib/test/H20231020.lean b/test/Mathlib/test/H20231020.lean
+index 670e12b..849e3c4 100644
+--- a/test/Mathlib/test/H20231020.lean
++++ b/test/Mathlib/test/H20231020.lean
+@@ -1,4 +1,4 @@
+-import Mathlib.Algebra.BigOperators.Group.Finset
++import Mathlib.Algebra.BigOperators.Basic
+ import Mathlib.Data.Real.Basic
+ import Mathlib.Data.Complex.Basic
+ import Mathlib.Data.Nat.Log
+diff --git a/test/Mathlib/test/H20231115.expected.out b/test/Mathlib/test/H20231115.expected.out
+index 2efb1d8..f386cb7 100644
+--- a/test/Mathlib/test/H20231115.expected.out
++++ b/test/Mathlib/test/H20231115.expected.out
+@@ -14,6 +14,6 @@
+ 
+ {"proofState": 1,
+  "goals":
+- ["case zero\n⊢ 0 + 1 > 0",
+-  "case succ\nx : Nat\nhx : x + 1 > x\n⊢ x + 1 + 1 > x + 1"]}
++ ["case zero\n⊢ Nat.zero + 1 > Nat.zero",
++  "case succ\nx : Nat\nhx : x + 1 > x\n⊢ Nat.succ x + 1 > Nat.succ x"]}
+ 
+diff --git a/test/Mathlib/test/H20231115_2.expected.out b/test/Mathlib/test/H20231115_2.expected.out
+index 3c19b57..39d6142 100644
+--- a/test/Mathlib/test/H20231115_2.expected.out
++++ b/test/Mathlib/test/H20231115_2.expected.out
+@@ -3,11 +3,11 @@
+ {"sorries":
+  [{"proofState": 0,
+    "pos": {"line": 3, "column": 12},
+-   "goal": "case zero\n⊢ 0 + 1 > 0",
++   "goal": "case zero\n⊢ Nat.zero + 1 > Nat.zero",
+    "endPos": {"line": 3, "column": 17}},
+   {"proofState": 1,
+    "pos": {"line": 3, "column": 12},
+-   "goal": "case succ\nx : Nat\nhx : x + 1 > x\n⊢ x + 1 + 1 > x + 1",
++   "goal": "case succ\nx : Nat\nhx : x + 1 > x\n⊢ Nat.succ x + 1 > Nat.succ x",
+    "endPos": {"line": 3, "column": 17}}],
+  "messages":
+  [{"severity": "warning",
+diff --git a/test/Mathlib/test/H20231115_3.expected.out b/test/Mathlib/test/H20231115_3.expected.out
+index 3b72d40..45b397f 100644
+--- a/test/Mathlib/test/H20231115_3.expected.out
++++ b/test/Mathlib/test/H20231115_3.expected.out
+@@ -5,6 +5,6 @@
+    "pos": {"line": 1, "column": 33},
+    "endPos": {"line": 2, "column": 24},
+    "data":
+-   "unsolved goals\ncase zero\n⊢ 0 + 1 > 0\n\ncase succ\nx : Nat\nhx : x + 1 > x\n⊢ x + 1 + 1 > x + 1"}],
++   "unsolved goals\ncase zero\n⊢ Nat.zero + 1 > Nat.zero\n\ncase succ\nx : Nat\nhx : x + 1 > x\n⊢ Nat.succ x + 1 > Nat.succ x"}],
+  "env": 1}
+ 
+diff --git a/test/Mathlib/test/H20231214.lean b/test/Mathlib/test/H20231214.lean
+index fc8ad1c..24f3f20 100644
+--- a/test/Mathlib/test/H20231214.lean
++++ b/test/Mathlib/test/H20231214.lean
+@@ -12,14 +12,6 @@ but is expected to have type
+   p x = 6 / x * p x : Prop
+ ---
+ error: unsolved goals
+-case calc.step
+-p q : ℝ → ℝ
+-h₀ : ∀ (x : ℝ), p x = 2 - x ^ 2
+-h₁ : ∀ (x : ℝ), x ≠ 0 → q x = 6 / x
+-x : ℝ
+-⊢ 6 / 2 * 6 / x * (6 / x) = 6 / x
+----
+-error: unsolved goals
+ p q : ℝ → ℝ
+ h₀ : ∀ (x : ℝ), p x = 2 - x ^ 2
+ h₁ : ∀ (x : ℝ), x ≠ 0 → q x = 6 / x
+diff --git a/test/Mathlib/test/exact.expected.out b/test/Mathlib/test/exact.expected.out
+index 86cd1c6..1c1a057 100644
+--- a/test/Mathlib/test/exact.expected.out
++++ b/test/Mathlib/test/exact.expected.out
+@@ -17,7 +17,7 @@
+  [{"severity": "info",
+    "pos": {"line": 0, "column": 0},
+    "endPos": {"line": 0, "column": 0},
+-   "data": "Try this: exact Nat.one_pos"}],
++   "data": "Try this: exact Nat.zero_lt_one"}],
+  "goals": []}
+ 
+ {"sorries":
+diff --git a/test/Mathlib/test/exact.in b/test/Mathlib/test/exact.in
+index 72b4c50..5764c0f 100644
+--- a/test/Mathlib/test/exact.in
++++ b/test/Mathlib/test/exact.in
+@@ -1,4 +1,4 @@
+-{"cmd": "import Mathlib"}
++{"cmd": "import Mathlib\n\nset_option maxHeartbeats 500000"}
+ 
+ {"cmd": "theorem test : 0 < 1 := by sorry", "env": 0}
+ 
+diff --git a/test/Mathlib/test/induction.expected.out b/test/Mathlib/test/induction.expected.out
+index 7ef34d3..8e19362 100644
+--- a/test/Mathlib/test/induction.expected.out
++++ b/test/Mathlib/test/induction.expected.out
+@@ -14,14 +14,16 @@
+ 
+ {"proofState": 1,
+  "goals":
+- ["case zero\n⊢ 0 = 0", "case succ\nn✝ : ℕ\na✝ : n✝ = n✝\n⊢ n✝ + 1 = n✝ + 1"]}
++ ["case zero\n⊢ Nat.zero = Nat.zero",
++  "case succ\nn✝ : ℕ\nn_ih✝ : n✝ = n✝\n⊢ Nat.succ n✝ = Nat.succ n✝"]}
+ 
+ {"proofState": 2,
+- "goals": ["case succ\nn✝ : ℕ\na✝ : n✝ = n✝\n⊢ n✝ + 1 = n✝ + 1"]}
++ "goals": ["case succ\nn✝ : ℕ\nn_ih✝ : n✝ = n✝\n⊢ Nat.succ n✝ = Nat.succ n✝"]}
+ 
+ {"sorries":
+- [{"proofState": 3, "goal": "case zero\n⊢ 0 = 0"},
+-  {"proofState": 4, "goal": "case succ\nx : ℕ\na✝ : x = x\n⊢ x + 1 = x + 1"}],
++ [{"proofState": 3, "goal": "case zero\n⊢ Nat.zero = Nat.zero"},
++  {"proofState": 4,
++   "goal": "case succ\nx : ℕ\nn_ih✝ : x = x\n⊢ Nat.succ x = Nat.succ x"}],
+  "proofState": 5,
+  "goals": []}
+ 
+diff --git a/test/all_tactics.expected.out b/test/all_tactics.expected.out
+index 6ec808c..5374db8 100644
+--- a/test/all_tactics.expected.out
++++ b/test/all_tactics.expected.out
+@@ -9,7 +9,7 @@
+    "tactic": "exact t",
+    "proofState": 1,
+    "pos": {"line": 1, "column": 32},
+-   "goals": "t : Nat\n⊢ Nat",
++   "goals": "t : Nat ⊢ Nat",
+    "endPos": {"line": 1, "column": 39}}],
+  "env": 0}
+ 
+diff --git a/test/calc.expected.out b/test/calc.expected.out
+index 94f6a9f..fde8fee 100644
+--- a/test/calc.expected.out
++++ b/test/calc.expected.out
+@@ -1,35 +1,22 @@
+ {"tactics":
+  [{"usedConstants":
+-   ["Trans.trans",
+-    "sorryAx",
+-    "instOfNatNat",
+-    "instTransEq",
+-    "Nat",
+-    "OfNat.ofNat",
+-    "Bool.false",
+-    "Eq"],
++   ["Trans.trans", "instOfNatNat", "instTransEq", "Nat", "OfNat.ofNat", "Eq"],
+    "tactic": "calc\n  3 = 4 := by sorry\n  4 = 5 := by sorry",
+    "proofState": 2,
+    "pos": {"line": 1, "column": 22},
+    "goals": "⊢ 3 = 5",
+    "endPos": {"line": 3, "column": 19}},
+-  {"usedConstants": [],
+-   "tactic": "\n  3 = 4 := by sorry\n  4 = 5 := by sorry",
+-   "proofState": 3,
+-   "pos": {"line": 2, "column": 2},
+-   "goals": "no goals",
+-   "endPos": {"line": 3, "column": 19}},
+   {"usedConstants":
+    ["sorryAx", "instOfNatNat", "Nat", "OfNat.ofNat", "Bool.false", "Eq"],
+    "tactic": "sorry",
+-   "proofState": 4,
++   "proofState": 3,
+    "pos": {"line": 2, "column": 14},
+    "goals": "⊢ 3 = 4",
+    "endPos": {"line": 2, "column": 19}},
+   {"usedConstants":
+    ["sorryAx", "instOfNatNat", "Nat", "OfNat.ofNat", "Bool.false", "Eq"],
+    "tactic": "sorry",
+-   "proofState": 5,
++   "proofState": 4,
+    "pos": {"line": 3, "column": 14},
+    "goals": "⊢ 4 = 5",
+    "endPos": {"line": 3, "column": 19}}],
+diff --git a/test/infotree.expected.out b/test/infotree.expected.out
+index cb76c20..236e1ba 100644
+--- a/test/infotree.expected.out
++++ b/test/infotree.expected.out
+@@ -2,8 +2,7 @@
+  [{"severity": "warning",
+    "pos": {"line": 1, "column": 7},
+    "endPos": {"line": 1, "column": 8},
+-   "data":
+-   "unused variable `h`\nnote: this linter can be disabled with `set_option linter.unusedVariables false`"}],
++   "data": "unused variable `h` [linter.unusedVariables]"}],
+  "infotree":
+  [{"node":
+    {"stx":
+diff --git a/test/name_generator.expected.out b/test/name_generator.expected.out
+index b4d885b..557d03b 100644
+--- a/test/name_generator.expected.out
++++ b/test/name_generator.expected.out
+@@ -24,13 +24,13 @@
+  "goals": []}
+ 
+ {"traces":
+- ["[Meta.Tactic.simp.rewrite] gt_iff_lt:1000, x > 0 ==> 0 < x",
++ ["[Meta.Tactic.simp.rewrite] @gt_iff_lt:1000, x > 0 ==> 0 < x",
+   "[Meta.Tactic.simp.rewrite] h0:1000, 0 < x ==> True"],
+  "proofState": 6,
+  "goals": []}
+ 
+ {"traces":
+- ["[Meta.Tactic.simp.rewrite] gt_iff_lt:1000, x > 0 ==> 0 < x",
++ ["[Meta.Tactic.simp.rewrite] @gt_iff_lt:1000, x > 0 ==> 0 < x",
+   "[Meta.Tactic.simp.rewrite] h0:1000, 0 < x ==> True"],
+  "proofState": 7,
+  "goals": []}
+diff --git a/test/no_goal_sorry.expected.out b/test/no_goal_sorry.expected.out
+index 5c89f5a..5be11b7 100644
+--- a/test/no_goal_sorry.expected.out
++++ b/test/no_goal_sorry.expected.out
+@@ -4,8 +4,8 @@
+    "endPos": {"line": 2, "column": 18},
+    "data": "type expected, got\n  (set Nat : ?m.8 PUnit)"},
+   {"severity": "error",
+-   "pos": {"line": 2, "column": 22},
+-   "endPos": {"line": 2, "column": 24},
+-   "data": "Case tag 'body' not found.\n\nThere are no cases to select."}],
++   "pos": {"line": 3, "column": 2},
++   "endPos": {"line": 3, "column": 7},
++   "data": "no goals to be solved"}],
+  "env": 0}
+ 
+diff --git a/test/trace_simp.expected.out b/test/trace_simp.expected.out
+index 2a85844..1f6fbeb 100644
+--- a/test/trace_simp.expected.out
++++ b/test/trace_simp.expected.out
+@@ -9,7 +9,7 @@
+    "pos": {"line": 1, "column": 23},
+    "endPos": {"line": 1, "column": 27},
+    "data":
+-   "[Meta.Tactic.simp.rewrite] f_def:1000, f ==> 37\n[Meta.Tactic.simp.rewrite] eq_self:1000, 37 = 37 ==> True"}],
++   "[Meta.Tactic.simp.rewrite] f_def:1000, f ==> 37\n[Meta.Tactic.simp.rewrite] @eq_self:1000, 37 = 37 ==> True"}],
+  "env": 3}
+ 
+ {"sorries":
+@@ -28,7 +28,7 @@
+ 
+ {"traces":
+  ["[Meta.Tactic.simp.rewrite] f_def:1000, f ==> 37",
+-  "[Meta.Tactic.simp.rewrite] eq_self:1000, 37 = 37 ==> True"],
++  "[Meta.Tactic.simp.rewrite] @eq_self:1000, 37 = 37 ==> True"],
+  "proofState": 2,
+  "goals": []}
+ 
+diff --git a/test/variables.expected.out b/test/variables.expected.out
+index cd060cb..1504f9b 100644
+--- a/test/variables.expected.out
++++ b/test/variables.expected.out
+@@ -4,8 +4,7 @@
+  [{"severity": "warning",
+    "pos": {"line": 1, "column": 12},
+    "endPos": {"line": 1, "column": 13},
+-   "data":
+-   "unused variable `y`\nnote: this linter can be disabled with `set_option linter.unusedVariables false`"}],
++   "data": "unused variable `y` [linter.unusedVariables]"}],
+  "env": 1}
+ 
+ {"sorries":

--- a/versions/v4.8.0-rc1.diff
+++ b/versions/v4.8.0-rc1.diff
@@ -11,7 +11,7 @@ index 9cc0914..a2bb150 100644
 +  let trees := s.infoState.trees.toList.drop commandState.infoState.trees.size
 +
 +  pure (s, msgs, trees)
-
+ 
  /--
  Process some text input, with or without an existing command state.
 diff --git a/REPL/JSON.lean b/REPL/JSON.lean
@@ -20,7 +20,7 @@ index d5c5ba2..b63c5ea 100644
 +++ b/REPL/JSON.lean
 @@ -83,7 +83,7 @@ structure Sorry where
  deriving FromJson
-
+ 
  instance : ToJson Sorry where
 -  toJson r := Json.mkObj <| .flatten [
 +  toJson r := Json.mkObj <| .join [
@@ -29,7 +29,7 @@ index d5c5ba2..b63c5ea 100644
      if r.pos.line ≠ 0 then [("pos", toJson r.pos)] else [],
 @@ -132,7 +132,7 @@ def Json.nonemptyList [ToJson α] (k : String) : List α → List (String × Jso
    | l  => [⟨k, toJson l⟩]
-
+ 
  instance : ToJson CommandResponse where
 -  toJson r := Json.mkObj <| .flatten [
 +  toJson r := Json.mkObj <| .join [
@@ -38,7 +38,7 @@ index d5c5ba2..b63c5ea 100644
      Json.nonemptyList "sorries" r.sorries,
 @@ -153,7 +153,7 @@ structure ProofStepResponse where
  deriving ToJson, FromJson
-
+ 
  instance : ToJson ProofStepResponse where
 -  toJson r := Json.mkObj <| .flatten [
 +  toJson r := Json.mkObj <| .join [
@@ -55,7 +55,7 @@ index 0b4be3c..61d4e76 100644
    let env ← importModules imports {} 0
 -  return (← env.replay (Std.HashMap.ofList map₂.toList), region)
 +  return (← env.replay (HashMap.ofList map₂.toList), region)
-
+ 
  end Lean.Environment
 diff --git a/REPL/Lean/InfoTree.lean b/REPL/Lean/InfoTree.lean
 index 7abf0b8..d3b28c1 100644
@@ -71,7 +71,7 @@ index 7abf0b8..d3b28c1 100644
 -      (children.toList.map (filter p m)).flatten
 +      (children.toList.map (filter p m)).join
    | .hole mvar => if m mvar then [.hole mvar] else []
-
+ 
  /-- Discard all nodes besides `.context` nodes and `TacticInfo` nodes. -/
 @@ -156,7 +156,7 @@ partial def findAllInfo (t : InfoTree) (ctx? : Option ContextInfo) (p : Info →
    | context ctx t => t.findAllInfo (ctx.mergeIntoOuter? ctx?) p
@@ -81,18 +81,18 @@ index 7abf0b8..d3b28c1 100644
 +    let rest := ts.toList.bind (fun t => t.findAllInfo ctx? p)
      info ++ rest
    | _ => []
-
+ 
 @@ -214,13 +214,13 @@ def sorries (t : InfoTree) : List (ContextInfo × SorryType × Position × Posit
-
+ 
  def tactics (t : InfoTree) : List (ContextInfo × Syntax × List MVarId × Position × Position × Array Name) :=
      -- HACK: creating a child ngen
--  t.findTacticNodes.map fun ⟨i, ctx⟩ =>
--    let range := stxRange ctx.fileMap i.stx
--    ( { ctx with mctx := i.mctxBefore, ngen := ctx.ngen.mkChild.1 },
--      i.stx,
--      i.goalsBefore,
--      range.fst,
--      range.snd,
+-  t.findTacticNodes.map fun ⟨i, ctx⟩ => 
+-    let range := stxRange ctx.fileMap i.stx 
+-    ( { ctx with mctx := i.mctxBefore, ngen := ctx.ngen.mkChild.1 }, 
+-      i.stx, 
+-      i.goalsBefore, 
+-      range.fst, 
+-      range.snd, 
 +  t.findTacticNodes.map fun ⟨i, ctx⟩ =>
 +    let range := stxRange ctx.fileMap i.stx
 +    ( { ctx with mctx := i.mctxBefore, ngen := ctx.ngen.mkChild.1 },
@@ -101,15 +101,15 @@ index 7abf0b8..d3b28c1 100644
 +      range.fst,
 +      range.snd,
        i.getUsedConstantsAsSet.toArray )
-
-
+ 
+ 
 diff --git a/REPL/Main.lean b/REPL/Main.lean
 index a4b97c3..f990b22 100644
 --- a/REPL/Main.lean
 +++ b/REPL/Main.lean
 @@ -95,7 +95,7 @@ def recordProofSnapshot (proofState : ProofSnapshot) : M m Nat := do
    return id
-
+ 
  def sorries (trees : List InfoTree) (env? : Option Environment) : M m (List Sorry) :=
 -  trees.flatMap InfoTree.sorries |>.filter (fun t => match t.2.1 with
 +  trees.bind InfoTree.sorries |>.filter (fun t => match t.2.1 with
@@ -118,7 +118,7 @@ index a4b97c3..f990b22 100644
        fun ⟨ctx, g, pos, endPos⟩ => do
 @@ -117,7 +117,7 @@ def ppTactic (ctx : ContextInfo) (stx : Syntax) : IO Format :=
      pure "<failed to pretty print>"
-
+ 
  def tactics (trees : List InfoTree) : M m (List Tactic) :=
 -  trees.flatMap InfoTree.tactics |>.mapM
 +  trees.bind InfoTree.tactics |>.mapM
@@ -228,9 +228,9 @@ index 070ce3d..4a24ae9 100755
 --- a/test.sh
 +++ b/test.sh
 @@ -41,6 +41,6 @@ for infile in $IN_DIR/*.in; do
-
+ 
  done
-
+ 
 -# Run the Mathlib tests
 -cp lean-toolchain test/Mathlib/
 -cd test/Mathlib/ && ./test.sh
@@ -421,7 +421,7 @@ index 6ec808c..5374db8 100644
 +   "goals": "t : Nat ⊢ Nat",
     "endPos": {"line": 1, "column": 39}}],
   "env": 0}
-
+ 
 diff --git a/test/calc.expected.out b/test/calc.expected.out
 index 94f6a9f..fde8fee 100644
 --- a/test/calc.expected.out
@@ -471,14 +471,14 @@ index b4d885b..557d03b 100644
 +++ b/test/name_generator.expected.out
 @@ -24,13 +24,13 @@
   "goals": []}
-
+ 
  {"traces":
 - ["[Meta.Tactic.simp.rewrite] gt_iff_lt:1000, x > 0 ==> 0 < x",
 + ["[Meta.Tactic.simp.rewrite] @gt_iff_lt:1000, x > 0 ==> 0 < x",
    "[Meta.Tactic.simp.rewrite] h0:1000, 0 < x ==> True"],
   "proofState": 6,
   "goals": []}
-
+ 
  {"traces":
 - ["[Meta.Tactic.simp.rewrite] gt_iff_lt:1000, x > 0 ==> 0 < x",
 + ["[Meta.Tactic.simp.rewrite] @gt_iff_lt:1000, x > 0 ==> 0 < x",
@@ -500,7 +500,7 @@ index 5c89f5a..5be11b7 100644
 +   "endPos": {"line": 3, "column": 7},
 +   "data": "no goals to be solved"}],
   "env": 0}
-
+ 
 diff --git a/test/trace_simp.expected.out b/test/trace_simp.expected.out
 index 2a85844..1f6fbeb 100644
 --- a/test/trace_simp.expected.out
@@ -512,13 +512,14 @@ index 2a85844..1f6fbeb 100644
 -   "[Meta.Tactic.simp.rewrite] f_def:1000, f ==> 37\n[Meta.Tactic.simp.rewrite] eq_self:1000, 37 = 37 ==> True"}],
 +   "[Meta.Tactic.simp.rewrite] f_def:1000, f ==> 37\n[Meta.Tactic.simp.rewrite] @eq_self:1000, 37 = 37 ==> True"}],
   "env": 3}
-
+ 
  {"sorries":
 @@ -28,7 +28,7 @@
-
+ 
  {"traces":
   ["[Meta.Tactic.simp.rewrite] f_def:1000, f ==> 37",
 -  "[Meta.Tactic.simp.rewrite] eq_self:1000, 37 = 37 ==> True"],
 +  "[Meta.Tactic.simp.rewrite] @eq_self:1000, 37 = 37 ==> True"],
   "proofState": 2,
   "goals": []}
+ 

--- a/versions/v4.8.0-rc1.diff
+++ b/versions/v4.8.0-rc1.diff
@@ -179,6 +179,27 @@ index f80f175..7eec48b 100644
   "packagesDir": ".lake/packages",
   "packages": [],
   "name": "REPL",
+diff --git a/lakefile.lean b/lakefile.lean
+new file mode 100644
+index 0000000..33dd0da
+--- /dev/null
++++ b/lakefile.lean
+@@ -0,0 +1,15 @@
++import Lake
++open Lake DSL
++
++package REPL {
++  -- add package configuration options here
++}
++
++lean_lib REPL {
++  -- add library configuration options here
++}
++
++@[default_target]
++lean_exe repl where
++  root := `REPL.Main
++  supportInterpreter := true
 diff --git a/lakefile.toml b/lakefile.toml
 deleted file mode 100644
 index 589e047..0000000
@@ -332,6 +353,23 @@ index f312e5a..2c242de 100644
 +   "configFile": "lakefile.lean"}],
   "name": "«repl-mathlib-tests»",
   "lakeDir": ".lake"}
+diff --git a/test/Mathlib/lakefile.lean b/test/Mathlib/lakefile.lean
+new file mode 100644
+index 0000000..c3dfb14
+--- /dev/null
++++ b/test/Mathlib/lakefile.lean
+@@ -0,0 +1,11 @@
++import Lake
++open Lake DSL
++
++package «repl-mathlib-tests» where
++  -- add package configuration options here
++  require mathlib from git "https://github.com/leanprover-community/mathlib4" @ "v4.8.0-rc1"
++
++@[default_target]
++lean_lib «ReplMathlibTests» where
++  globs := #[.submodules `test]
++  -- add library configuration options here
 diff --git a/test/Mathlib/lakefile.toml b/test/Mathlib/lakefile.toml
 deleted file mode 100644
 index 6ff9631..0000000

--- a/versions/v4.8.0-rc1.diff
+++ b/versions/v4.8.0-rc1.diff
@@ -1,0 +1,473 @@
+diff --git a/REPL/Frontend.lean b/REPL/Frontend.lean
+index 9cc0914..a2bb150 100644
+--- a/REPL/Frontend.lean
++++ b/REPL/Frontend.lean
+@@ -20,7 +20,10 @@ def processCommandsWithInfoTrees
+     (commandState : Command.State) : IO (Command.State × List Message × List InfoTree) := do
+   let commandState := { commandState with infoState.enabled := true }
+   let s ← IO.processCommands inputCtx parserState commandState <&> Frontend.State.commandState
+-  pure (s, s.messages.toList, s.infoState.trees.toList)
++  let msgs := s.messages.toList.drop commandState.messages.toList.length
++  let trees := s.infoState.trees.toList.drop commandState.infoState.trees.size
++
++  pure (s, msgs, trees)
+ 
+ /--
+ Process some text input, with or without an existing command state.
+diff --git a/REPL/JSON.lean b/REPL/JSON.lean
+index d5c5ba2..b63c5ea 100644
+--- a/REPL/JSON.lean
++++ b/REPL/JSON.lean
+@@ -83,7 +83,7 @@ structure Sorry where
+ deriving FromJson
+ 
+ instance : ToJson Sorry where
+-  toJson r := Json.mkObj <| .flatten [
++  toJson r := Json.mkObj <| .join [
+     [("goal", r.goal)],
+     [("proofState", toJson r.proofState)],
+     if r.pos.line ≠ 0 then [("pos", toJson r.pos)] else [],
+@@ -132,7 +132,7 @@ def Json.nonemptyList [ToJson α] (k : String) : List α → List (String × Jso
+   | l  => [⟨k, toJson l⟩]
+ 
+ instance : ToJson CommandResponse where
+-  toJson r := Json.mkObj <| .flatten [
++  toJson r := Json.mkObj <| .join [
+     [("env", r.env)],
+     Json.nonemptyList "messages" r.messages,
+     Json.nonemptyList "sorries" r.sorries,
+@@ -153,7 +153,7 @@ structure ProofStepResponse where
+ deriving ToJson, FromJson
+ 
+ instance : ToJson ProofStepResponse where
+-  toJson r := Json.mkObj <| .flatten [
++  toJson r := Json.mkObj <| .join [
+     [("proofState", r.proofState)],
+     [("goals", toJson r.goals)],
+     Json.nonemptyList "messages" r.messages,
+diff --git a/REPL/Lean/Environment.lean b/REPL/Lean/Environment.lean
+index 0b4be3c..61d4e76 100644
+--- a/REPL/Lean/Environment.lean
++++ b/REPL/Lean/Environment.lean
+@@ -26,6 +26,6 @@ and then replace the new constants.
+ def unpickle (path : FilePath) : IO (Environment × CompactedRegion) := unsafe do
+   let ((imports, map₂), region) ← _root_.unpickle (Array Import × PHashMap Name ConstantInfo) path
+   let env ← importModules imports {} 0
+-  return (← env.replay (Std.HashMap.ofList map₂.toList), region)
++  return (← env.replay (HashMap.ofList map₂.toList), region)
+ 
+ end Lean.Environment
+diff --git a/REPL/Lean/InfoTree.lean b/REPL/Lean/InfoTree.lean
+index 7abf0b8..d3b28c1 100644
+--- a/REPL/Lean/InfoTree.lean
++++ b/REPL/Lean/InfoTree.lean
+@@ -131,9 +131,9 @@ partial def filter (p : Info → Bool) (m : MVarId → Bool := fun _ => false) :
+   | .context ctx tree => tree.filter p m |>.map (.context ctx)
+   | .node info children =>
+     if p info then
+-      [.node info (children.toList.map (filter p m)).flatten.toPArray']
++      [.node info (children.toList.map (filter p m)).join.toPArray']
+     else
+-      (children.toList.map (filter p m)).flatten
++      (children.toList.map (filter p m)).join
+   | .hole mvar => if m mvar then [.hole mvar] else []
+ 
+ /-- Discard all nodes besides `.context` nodes and `TacticInfo` nodes. -/
+@@ -156,7 +156,7 @@ partial def findAllInfo (t : InfoTree) (ctx? : Option ContextInfo) (p : Info →
+   | context ctx t => t.findAllInfo (ctx.mergeIntoOuter? ctx?) p
+   | node i ts  =>
+     let info := if p i then [(i, ctx?)] else []
+-    let rest := ts.toList.flatMap (fun t => t.findAllInfo ctx? p)
++    let rest := ts.toList.bind (fun t => t.findAllInfo ctx? p)
+     info ++ rest
+   | _ => []
+ 
+@@ -214,13 +214,13 @@ def sorries (t : InfoTree) : List (ContextInfo × SorryType × Position × Posit
+ 
+ def tactics (t : InfoTree) : List (ContextInfo × Syntax × List MVarId × Position × Position × Array Name) :=
+     -- HACK: creating a child ngen
+-  t.findTacticNodes.map fun ⟨i, ctx⟩ => 
+-    let range := stxRange ctx.fileMap i.stx 
+-    ( { ctx with mctx := i.mctxBefore, ngen := ctx.ngen.mkChild.1 }, 
+-      i.stx, 
+-      i.goalsBefore, 
+-      range.fst, 
+-      range.snd, 
++  t.findTacticNodes.map fun ⟨i, ctx⟩ =>
++    let range := stxRange ctx.fileMap i.stx
++    ( { ctx with mctx := i.mctxBefore, ngen := ctx.ngen.mkChild.1 },
++      i.stx,
++      i.goalsBefore,
++      range.fst,
++      range.snd,
+       i.getUsedConstantsAsSet.toArray )
+ 
+ 
+diff --git a/REPL/Main.lean b/REPL/Main.lean
+index a4b97c3..f990b22 100644
+--- a/REPL/Main.lean
++++ b/REPL/Main.lean
+@@ -95,7 +95,7 @@ def recordProofSnapshot (proofState : ProofSnapshot) : M m Nat := do
+   return id
+ 
+ def sorries (trees : List InfoTree) (env? : Option Environment) : M m (List Sorry) :=
+-  trees.flatMap InfoTree.sorries |>.filter (fun t => match t.2.1 with
++  trees.bind InfoTree.sorries |>.filter (fun t => match t.2.1 with
+     | .term _ none => false
+     | _ => true ) |>.mapM
+       fun ⟨ctx, g, pos, endPos⟩ => do
+@@ -117,7 +117,7 @@ def ppTactic (ctx : ContextInfo) (stx : Syntax) : IO Format :=
+     pure "<failed to pretty print>"
+ 
+ def tactics (trees : List InfoTree) : M m (List Tactic) :=
+-  trees.flatMap InfoTree.tactics |>.mapM
++  trees.bind InfoTree.tactics |>.mapM
+     fun ⟨ctx, stx, goals, pos, endPos, ns⟩ => do
+       let proofState := some (← ProofSnapshot.create ctx none none goals)
+       let goals := s!"{(← ctx.ppGoals goals)}".trim
+@@ -213,14 +213,13 @@ def runCommand (s : Command) : M IO (CommandResponse ⊕ Error) := do
+       { fileName := "",
+         fileMap := default,
+         tacticCache? := none,
+-        snap? := none,
+-        cancelTk? := none } }
++        snap? := none } }
+   let env ← recordCommandSnapshot cmdSnapshot
+   let jsonTrees := match s.infotree with
+   | some "full" => trees
+-  | some "tactics" => trees.flatMap InfoTree.retainTacticInfo
+-  | some "original" => trees.flatMap InfoTree.retainTacticInfo |>.flatMap InfoTree.retainOriginal
+-  | some "substantive" => trees.flatMap InfoTree.retainTacticInfo |>.flatMap InfoTree.retainSubstantive
++  | some "tactics" => trees.bind InfoTree.retainTacticInfo
++  | some "original" => trees.bind InfoTree.retainTacticInfo |>.bind InfoTree.retainOriginal
++  | some "substantive" => trees.bind InfoTree.retainTacticInfo |>.bind InfoTree.retainSubstantive
+   | _ => []
+   let infotree ← if jsonTrees.isEmpty then
+     pure none
+diff --git a/REPL/Snapshots.lean b/REPL/Snapshots.lean
+index 1114c24..7462141 100644
+--- a/REPL/Snapshots.lean
++++ b/REPL/Snapshots.lean
+@@ -83,7 +83,7 @@ def unpickle (path : FilePath) : IO (CommandSnapshot × CompactedRegion) := unsa
+   let ((imports, map₂, cmdState, cmdContext), region) ←
+     _root_.unpickle (Array Import × PHashMap Name ConstantInfo × CompactableCommandSnapshot ×
+       Command.Context) path
+-  let env ← (← importModules imports {} 0).replay (Std.HashMap.ofList map₂.toList)
++  let env ← (← importModules imports {} 0).replay (HashMap.ofList map₂.toList)
+   let p' : CommandSnapshot :=
+   { cmdState := { cmdState with env }
+     cmdContext }
+@@ -284,9 +284,9 @@ def unpickle (path : FilePath) (cmd? : Option CommandSnapshot) :
+   let env ← match cmd? with
+   | none =>
+     enableInitializersExecution
+-    (← importModules imports {} 0).replay (Std.HashMap.ofList map₂.toList)
++    (← importModules imports {} 0).replay (HashMap.ofList map₂.toList)
+   | some cmd =>
+-    cmd.cmdState.env.replay (Std.HashMap.ofList map₂.toList)
++    cmd.cmdState.env.replay (HashMap.ofList map₂.toList)
+   let p' : ProofSnapshot :=
+   { coreState := { coreState with env }
+     coreContext
+diff --git a/lake-manifest.json b/lake-manifest.json
+index f80f175..7eec48b 100644
+--- a/lake-manifest.json
++++ b/lake-manifest.json
+@@ -1,4 +1,4 @@
+-{"version": "1.1.0",
++{"version": 7,
+  "packagesDir": ".lake/packages",
+  "packages": [],
+  "name": "REPL",
+diff --git a/lakefile.toml b/lakefile.toml
+deleted file mode 100644
+index 589e047..0000000
+--- a/lakefile.toml
++++ /dev/null
+@@ -1,10 +0,0 @@
+-name = "REPL"
+-defaultTargets = ["repl"]
+-
+-[[lean_lib]]
+-name = "REPL"
+-
+-[[lean_exe]]
+-name = "repl"
+-root = "REPL.Main"
+-supportInterpreter = true
+diff --git a/lean-toolchain b/lean-toolchain
+index 1e70935..d8a6d7e 100644
+--- a/lean-toolchain
++++ b/lean-toolchain
+@@ -1 +1 @@
+-leanprover/lean4:v4.14.0
++leanprover/lean4:v4.8.0-rc1
+diff --git a/test/Mathlib/lake-manifest.json b/test/Mathlib/lake-manifest.json
+index f312e5a..2c242de 100644
+--- a/test/Mathlib/lake-manifest.json
++++ b/test/Mathlib/lake-manifest.json
+@@ -1,95 +1,68 @@
+-{"version": "1.1.0",
++{"version": 7,
+  "packagesDir": ".lake/packages",
+  "packages":
+- [{"url": "https://github.com/leanprover-community/mathlib4",
++ [{"url": "https://github.com/leanprover-community/batteries",
+    "type": "git",
+    "subDir": null,
+-   "scope": "",
+-   "rev": "4bbdccd9c5f862bf90ff12f0a9e2c8be032b9a84",
+-   "name": "mathlib",
+-   "manifestFile": "lake-manifest.json",
+-   "inputRev": "v4.14.0",
+-   "inherited": false,
+-   "configFile": "lakefile.lean"},
+-  {"url": "https://github.com/leanprover-community/plausible",
+-   "type": "git",
+-   "subDir": null,
+-   "scope": "leanprover-community",
+-   "rev": "42dc02bdbc5d0c2f395718462a76c3d87318f7fa",
+-   "name": "plausible",
++   "rev": "551ff2d7dffd7af914cdbd01abbd449fe3e3d428",
++   "name": "batteries",
+    "manifestFile": "lake-manifest.json",
+    "inputRev": "main",
+    "inherited": true,
+-   "configFile": "lakefile.toml"},
+-  {"url": "https://github.com/leanprover-community/LeanSearchClient",
++   "configFile": "lakefile.lean"},
++  {"url": "https://github.com/leanprover-community/quote4",
+    "type": "git",
+    "subDir": null,
+-   "scope": "leanprover-community",
+-   "rev": "d7caecce0d0f003fd5e9cce9a61f1dd6ba83142b",
+-   "name": "LeanSearchClient",
++   "rev": "53156671405fbbd5402ed17a79bd129b961bd8d6",
++   "name": "Qq",
+    "manifestFile": "lake-manifest.json",
+-   "inputRev": "main",
++   "inputRev": "master",
+    "inherited": true,
+-   "configFile": "lakefile.toml"},
+-  {"url": "https://github.com/leanprover-community/import-graph",
++   "configFile": "lakefile.lean"},
++  {"url": "https://github.com/leanprover-community/aesop",
+    "type": "git",
+    "subDir": null,
+-   "scope": "leanprover-community",
+-   "rev": "519e509a28864af5bed98033dd33b95cf08e9aa7",
+-   "name": "importGraph",
++   "rev": "53ba96ad7666d4a2515292974631629b5ea5dfee",
++   "name": "aesop",
+    "manifestFile": "lake-manifest.json",
+-   "inputRev": "v4.14.0",
++   "inputRev": "master",
+    "inherited": true,
+    "configFile": "lakefile.toml"},
+   {"url": "https://github.com/leanprover-community/ProofWidgets4",
+    "type": "git",
+    "subDir": null,
+-   "scope": "leanprover-community",
+-   "rev": "68280daef58803f68368eb2e53046dabcd270c9d",
++   "rev": "e6b6247c61280c77ade6bbf0bc3c66a44fe2e0c5",
+    "name": "proofwidgets",
+    "manifestFile": "lake-manifest.json",
+-   "inputRev": "v0.0.47",
++   "inputRev": "v0.0.36",
+    "inherited": true,
+    "configFile": "lakefile.lean"},
+-  {"url": "https://github.com/leanprover-community/aesop",
+-   "type": "git",
+-   "subDir": null,
+-   "scope": "leanprover-community",
+-   "rev": "5a0ec8588855265ade536f35bcdcf0fb24fd6030",
+-   "name": "aesop",
+-   "manifestFile": "lake-manifest.json",
+-   "inputRev": "v4.14.0",
+-   "inherited": true,
+-   "configFile": "lakefile.toml"},
+-  {"url": "https://github.com/leanprover-community/quote4",
++  {"url": "https://github.com/leanprover/lean4-cli",
+    "type": "git",
+    "subDir": null,
+-   "scope": "leanprover-community",
+-   "rev": "303b23fbcea94ac4f96e590c1cad6618fd4f5f41",
+-   "name": "Qq",
++   "rev": "a11566029bd9ec4f68a65394e8c3ff1af74c1a29",
++   "name": "Cli",
+    "manifestFile": "lake-manifest.json",
+-   "inputRev": "master",
++   "inputRev": "main",
+    "inherited": true,
+    "configFile": "lakefile.lean"},
+-  {"url": "https://github.com/leanprover-community/batteries",
++  {"url": "https://github.com/leanprover-community/import-graph.git",
+    "type": "git",
+    "subDir": null,
+-   "scope": "leanprover-community",
+-   "rev": "8d6c853f11a5172efa0e96b9f2be1a83d861cdd9",
+-   "name": "batteries",
++   "rev": "77e081815b30b0d30707e1c5b0c6a6761f7a2404",
++   "name": "importGraph",
+    "manifestFile": "lake-manifest.json",
+-   "inputRev": "v4.14.0",
++   "inputRev": "main",
+    "inherited": true,
+    "configFile": "lakefile.toml"},
+-  {"url": "https://github.com/leanprover/lean4-cli",
++  {"url": "https://github.com/leanprover-community/mathlib4",
+    "type": "git",
+    "subDir": null,
+-   "scope": "leanprover",
+-   "rev": "726b3c9ad13acca724d4651f14afc4804a7b0e4d",
+-   "name": "Cli",
++   "rev": "b5eba595428809e96f3ed113bc7ba776c5f801ac",
++   "name": "mathlib",
+    "manifestFile": "lake-manifest.json",
+-   "inputRev": "main",
+-   "inherited": true,
+-   "configFile": "lakefile.toml"}],
++   "inputRev": "v4.8.0",
++   "inherited": false,
++   "configFile": "lakefile.lean"}],
+  "name": "«repl-mathlib-tests»",
+  "lakeDir": ".lake"}
+diff --git a/test/Mathlib/lakefile.toml b/test/Mathlib/lakefile.toml
+deleted file mode 100644
+index 6ff9631..0000000
+--- a/test/Mathlib/lakefile.toml
++++ /dev/null
+@@ -1,11 +0,0 @@
+-name = "«repl-mathlib-tests»"
+-defaultTargets = ["ReplMathlibTests"]
+-
+-[[require]]
+-name = "mathlib"
+-git = "https://github.com/leanprover-community/mathlib4"
+-rev = "v4.14.0"
+-
+-[[lean_lib]]
+-name = "ReplMathlibTests"
+-globs = ["test.+"]
+diff --git a/test/Mathlib/lean-toolchain b/test/Mathlib/lean-toolchain
+index 401bc14..d8a6d7e 100644
+--- a/test/Mathlib/lean-toolchain
++++ b/test/Mathlib/lean-toolchain
+@@ -1 +1 @@
+-leanprover/lean4:v4.14.0
+\ No newline at end of file
++leanprover/lean4:v4.8.0-rc1
+diff --git a/test/all_tactics.expected.out b/test/all_tactics.expected.out
+index 6ec808c..5374db8 100644
+--- a/test/all_tactics.expected.out
++++ b/test/all_tactics.expected.out
+@@ -9,7 +9,7 @@
+    "tactic": "exact t",
+    "proofState": 1,
+    "pos": {"line": 1, "column": 32},
+-   "goals": "t : Nat\n⊢ Nat",
++   "goals": "t : Nat ⊢ Nat",
+    "endPos": {"line": 1, "column": 39}}],
+  "env": 0}
+ 
+diff --git a/test/calc.expected.out b/test/calc.expected.out
+index 94f6a9f..fde8fee 100644
+--- a/test/calc.expected.out
++++ b/test/calc.expected.out
+@@ -1,35 +1,22 @@
+ {"tactics":
+  [{"usedConstants":
+-   ["Trans.trans",
+-    "sorryAx",
+-    "instOfNatNat",
+-    "instTransEq",
+-    "Nat",
+-    "OfNat.ofNat",
+-    "Bool.false",
+-    "Eq"],
++   ["Trans.trans", "instOfNatNat", "instTransEq", "Nat", "OfNat.ofNat", "Eq"],
+    "tactic": "calc\n  3 = 4 := by sorry\n  4 = 5 := by sorry",
+    "proofState": 2,
+    "pos": {"line": 1, "column": 22},
+    "goals": "⊢ 3 = 5",
+    "endPos": {"line": 3, "column": 19}},
+-  {"usedConstants": [],
+-   "tactic": "\n  3 = 4 := by sorry\n  4 = 5 := by sorry",
+-   "proofState": 3,
+-   "pos": {"line": 2, "column": 2},
+-   "goals": "no goals",
+-   "endPos": {"line": 3, "column": 19}},
+   {"usedConstants":
+    ["sorryAx", "instOfNatNat", "Nat", "OfNat.ofNat", "Bool.false", "Eq"],
+    "tactic": "sorry",
+-   "proofState": 4,
++   "proofState": 3,
+    "pos": {"line": 2, "column": 14},
+    "goals": "⊢ 3 = 4",
+    "endPos": {"line": 2, "column": 19}},
+   {"usedConstants":
+    ["sorryAx", "instOfNatNat", "Nat", "OfNat.ofNat", "Bool.false", "Eq"],
+    "tactic": "sorry",
+-   "proofState": 5,
++   "proofState": 4,
+    "pos": {"line": 3, "column": 14},
+    "goals": "⊢ 4 = 5",
+    "endPos": {"line": 3, "column": 19}}],
+diff --git a/test/name_generator.expected.out b/test/name_generator.expected.out
+index b4d885b..557d03b 100644
+--- a/test/name_generator.expected.out
++++ b/test/name_generator.expected.out
+@@ -24,13 +24,13 @@
+  "goals": []}
+ 
+ {"traces":
+- ["[Meta.Tactic.simp.rewrite] gt_iff_lt:1000, x > 0 ==> 0 < x",
++ ["[Meta.Tactic.simp.rewrite] @gt_iff_lt:1000, x > 0 ==> 0 < x",
+   "[Meta.Tactic.simp.rewrite] h0:1000, 0 < x ==> True"],
+  "proofState": 6,
+  "goals": []}
+ 
+ {"traces":
+- ["[Meta.Tactic.simp.rewrite] gt_iff_lt:1000, x > 0 ==> 0 < x",
++ ["[Meta.Tactic.simp.rewrite] @gt_iff_lt:1000, x > 0 ==> 0 < x",
+   "[Meta.Tactic.simp.rewrite] h0:1000, 0 < x ==> True"],
+  "proofState": 7,
+  "goals": []}
+diff --git a/test/no_goal_sorry.expected.out b/test/no_goal_sorry.expected.out
+index 5c89f5a..5be11b7 100644
+--- a/test/no_goal_sorry.expected.out
++++ b/test/no_goal_sorry.expected.out
+@@ -4,8 +4,8 @@
+    "endPos": {"line": 2, "column": 18},
+    "data": "type expected, got\n  (set Nat : ?m.8 PUnit)"},
+   {"severity": "error",
+-   "pos": {"line": 2, "column": 22},
+-   "endPos": {"line": 2, "column": 24},
+-   "data": "Case tag 'body' not found.\n\nThere are no cases to select."}],
++   "pos": {"line": 3, "column": 2},
++   "endPos": {"line": 3, "column": 7},
++   "data": "no goals to be solved"}],
+  "env": 0}
+ 
+diff --git a/test/trace_simp.expected.out b/test/trace_simp.expected.out
+index 2a85844..1f6fbeb 100644
+--- a/test/trace_simp.expected.out
++++ b/test/trace_simp.expected.out
+@@ -9,7 +9,7 @@
+    "pos": {"line": 1, "column": 23},
+    "endPos": {"line": 1, "column": 27},
+    "data":
+-   "[Meta.Tactic.simp.rewrite] f_def:1000, f ==> 37\n[Meta.Tactic.simp.rewrite] eq_self:1000, 37 = 37 ==> True"}],
++   "[Meta.Tactic.simp.rewrite] f_def:1000, f ==> 37\n[Meta.Tactic.simp.rewrite] @eq_self:1000, 37 = 37 ==> True"}],
+  "env": 3}
+ 
+ {"sorries":
+@@ -28,7 +28,7 @@
+ 
+ {"traces":
+  ["[Meta.Tactic.simp.rewrite] f_def:1000, f ==> 37",
+-  "[Meta.Tactic.simp.rewrite] eq_self:1000, 37 = 37 ==> True"],
++  "[Meta.Tactic.simp.rewrite] @eq_self:1000, 37 = 37 ==> True"],
+  "proofState": 2,
+  "goals": []}
+ 

--- a/versions/v4.8.0-rc1.diff
+++ b/versions/v4.8.0-rc1.diff
@@ -11,7 +11,7 @@ index 9cc0914..a2bb150 100644
 +  let trees := s.infoState.trees.toList.drop commandState.infoState.trees.size
 +
 +  pure (s, msgs, trees)
- 
+
  /--
  Process some text input, with or without an existing command state.
 diff --git a/REPL/JSON.lean b/REPL/JSON.lean
@@ -20,7 +20,7 @@ index d5c5ba2..b63c5ea 100644
 +++ b/REPL/JSON.lean
 @@ -83,7 +83,7 @@ structure Sorry where
  deriving FromJson
- 
+
  instance : ToJson Sorry where
 -  toJson r := Json.mkObj <| .flatten [
 +  toJson r := Json.mkObj <| .join [
@@ -29,7 +29,7 @@ index d5c5ba2..b63c5ea 100644
      if r.pos.line ≠ 0 then [("pos", toJson r.pos)] else [],
 @@ -132,7 +132,7 @@ def Json.nonemptyList [ToJson α] (k : String) : List α → List (String × Jso
    | l  => [⟨k, toJson l⟩]
- 
+
  instance : ToJson CommandResponse where
 -  toJson r := Json.mkObj <| .flatten [
 +  toJson r := Json.mkObj <| .join [
@@ -38,7 +38,7 @@ index d5c5ba2..b63c5ea 100644
      Json.nonemptyList "sorries" r.sorries,
 @@ -153,7 +153,7 @@ structure ProofStepResponse where
  deriving ToJson, FromJson
- 
+
  instance : ToJson ProofStepResponse where
 -  toJson r := Json.mkObj <| .flatten [
 +  toJson r := Json.mkObj <| .join [
@@ -55,7 +55,7 @@ index 0b4be3c..61d4e76 100644
    let env ← importModules imports {} 0
 -  return (← env.replay (Std.HashMap.ofList map₂.toList), region)
 +  return (← env.replay (HashMap.ofList map₂.toList), region)
- 
+
  end Lean.Environment
 diff --git a/REPL/Lean/InfoTree.lean b/REPL/Lean/InfoTree.lean
 index 7abf0b8..d3b28c1 100644
@@ -71,7 +71,7 @@ index 7abf0b8..d3b28c1 100644
 -      (children.toList.map (filter p m)).flatten
 +      (children.toList.map (filter p m)).join
    | .hole mvar => if m mvar then [.hole mvar] else []
- 
+
  /-- Discard all nodes besides `.context` nodes and `TacticInfo` nodes. -/
 @@ -156,7 +156,7 @@ partial def findAllInfo (t : InfoTree) (ctx? : Option ContextInfo) (p : Info →
    | context ctx t => t.findAllInfo (ctx.mergeIntoOuter? ctx?) p
@@ -81,18 +81,18 @@ index 7abf0b8..d3b28c1 100644
 +    let rest := ts.toList.bind (fun t => t.findAllInfo ctx? p)
      info ++ rest
    | _ => []
- 
+
 @@ -214,13 +214,13 @@ def sorries (t : InfoTree) : List (ContextInfo × SorryType × Position × Posit
- 
+
  def tactics (t : InfoTree) : List (ContextInfo × Syntax × List MVarId × Position × Position × Array Name) :=
      -- HACK: creating a child ngen
--  t.findTacticNodes.map fun ⟨i, ctx⟩ => 
--    let range := stxRange ctx.fileMap i.stx 
--    ( { ctx with mctx := i.mctxBefore, ngen := ctx.ngen.mkChild.1 }, 
--      i.stx, 
--      i.goalsBefore, 
--      range.fst, 
--      range.snd, 
+-  t.findTacticNodes.map fun ⟨i, ctx⟩ =>
+-    let range := stxRange ctx.fileMap i.stx
+-    ( { ctx with mctx := i.mctxBefore, ngen := ctx.ngen.mkChild.1 },
+-      i.stx,
+-      i.goalsBefore,
+-      range.fst,
+-      range.snd,
 +  t.findTacticNodes.map fun ⟨i, ctx⟩ =>
 +    let range := stxRange ctx.fileMap i.stx
 +    ( { ctx with mctx := i.mctxBefore, ngen := ctx.ngen.mkChild.1 },
@@ -101,15 +101,15 @@ index 7abf0b8..d3b28c1 100644
 +      range.fst,
 +      range.snd,
        i.getUsedConstantsAsSet.toArray )
- 
- 
+
+
 diff --git a/REPL/Main.lean b/REPL/Main.lean
 index a4b97c3..f990b22 100644
 --- a/REPL/Main.lean
 +++ b/REPL/Main.lean
 @@ -95,7 +95,7 @@ def recordProofSnapshot (proofState : ProofSnapshot) : M m Nat := do
    return id
- 
+
  def sorries (trees : List InfoTree) (env? : Option Environment) : M m (List Sorry) :=
 -  trees.flatMap InfoTree.sorries |>.filter (fun t => match t.2.1 with
 +  trees.bind InfoTree.sorries |>.filter (fun t => match t.2.1 with
@@ -118,7 +118,7 @@ index a4b97c3..f990b22 100644
        fun ⟨ctx, g, pos, endPos⟩ => do
 @@ -117,7 +117,7 @@ def ppTactic (ctx : ContextInfo) (stx : Syntax) : IO Format :=
      pure "<failed to pretty print>"
- 
+
  def tactics (trees : List InfoTree) : M m (List Tactic) :=
 -  trees.flatMap InfoTree.tactics |>.mapM
 +  trees.bind InfoTree.tactics |>.mapM
@@ -223,6 +223,20 @@ index 1e70935..d8a6d7e 100644
 @@ -1 +1 @@
 -leanprover/lean4:v4.14.0
 +leanprover/lean4:v4.8.0-rc1
+diff --git a/test.sh b/test.sh
+index 070ce3d..4a24ae9 100755
+--- a/test.sh
++++ b/test.sh
+@@ -41,6 +41,6 @@ for infile in $IN_DIR/*.in; do
+
+ done
+
+-# Run the Mathlib tests
+-cp lean-toolchain test/Mathlib/
+-cd test/Mathlib/ && ./test.sh
++# Run the Mathlib tests - skipped as it takes too much time
++# cp lean-toolchain test/Mathlib/
++# cd test/Mathlib/ && ./test.sh
 diff --git a/test/Mathlib/lake-manifest.json b/test/Mathlib/lake-manifest.json
 index f312e5a..2c242de 100644
 --- a/test/Mathlib/lake-manifest.json
@@ -407,7 +421,7 @@ index 6ec808c..5374db8 100644
 +   "goals": "t : Nat ⊢ Nat",
     "endPos": {"line": 1, "column": 39}}],
   "env": 0}
- 
+
 diff --git a/test/calc.expected.out b/test/calc.expected.out
 index 94f6a9f..fde8fee 100644
 --- a/test/calc.expected.out
@@ -457,14 +471,14 @@ index b4d885b..557d03b 100644
 +++ b/test/name_generator.expected.out
 @@ -24,13 +24,13 @@
   "goals": []}
- 
+
  {"traces":
 - ["[Meta.Tactic.simp.rewrite] gt_iff_lt:1000, x > 0 ==> 0 < x",
 + ["[Meta.Tactic.simp.rewrite] @gt_iff_lt:1000, x > 0 ==> 0 < x",
    "[Meta.Tactic.simp.rewrite] h0:1000, 0 < x ==> True"],
   "proofState": 6,
   "goals": []}
- 
+
  {"traces":
 - ["[Meta.Tactic.simp.rewrite] gt_iff_lt:1000, x > 0 ==> 0 < x",
 + ["[Meta.Tactic.simp.rewrite] @gt_iff_lt:1000, x > 0 ==> 0 < x",
@@ -486,7 +500,7 @@ index 5c89f5a..5be11b7 100644
 +   "endPos": {"line": 3, "column": 7},
 +   "data": "no goals to be solved"}],
   "env": 0}
- 
+
 diff --git a/test/trace_simp.expected.out b/test/trace_simp.expected.out
 index 2a85844..1f6fbeb 100644
 --- a/test/trace_simp.expected.out
@@ -498,14 +512,13 @@ index 2a85844..1f6fbeb 100644
 -   "[Meta.Tactic.simp.rewrite] f_def:1000, f ==> 37\n[Meta.Tactic.simp.rewrite] eq_self:1000, 37 = 37 ==> True"}],
 +   "[Meta.Tactic.simp.rewrite] f_def:1000, f ==> 37\n[Meta.Tactic.simp.rewrite] @eq_self:1000, 37 = 37 ==> True"}],
   "env": 3}
- 
+
  {"sorries":
 @@ -28,7 +28,7 @@
- 
+
  {"traces":
   ["[Meta.Tactic.simp.rewrite] f_def:1000, f ==> 37",
 -  "[Meta.Tactic.simp.rewrite] eq_self:1000, 37 = 37 ==> True"],
 +  "[Meta.Tactic.simp.rewrite] @eq_self:1000, 37 = 37 ==> True"],
   "proofState": 2,
   "goals": []}
- 

--- a/versions/v4.8.0-rc2.diff
+++ b/versions/v4.8.0-rc2.diff
@@ -11,7 +11,7 @@ index 9cc0914..a2bb150 100644
 +  let trees := s.infoState.trees.toList.drop commandState.infoState.trees.size
 +
 +  pure (s, msgs, trees)
-
+ 
  /--
  Process some text input, with or without an existing command state.
 diff --git a/REPL/JSON.lean b/REPL/JSON.lean
@@ -20,7 +20,7 @@ index d5c5ba2..b63c5ea 100644
 +++ b/REPL/JSON.lean
 @@ -83,7 +83,7 @@ structure Sorry where
  deriving FromJson
-
+ 
  instance : ToJson Sorry where
 -  toJson r := Json.mkObj <| .flatten [
 +  toJson r := Json.mkObj <| .join [
@@ -29,7 +29,7 @@ index d5c5ba2..b63c5ea 100644
      if r.pos.line ≠ 0 then [("pos", toJson r.pos)] else [],
 @@ -132,7 +132,7 @@ def Json.nonemptyList [ToJson α] (k : String) : List α → List (String × Jso
    | l  => [⟨k, toJson l⟩]
-
+ 
  instance : ToJson CommandResponse where
 -  toJson r := Json.mkObj <| .flatten [
 +  toJson r := Json.mkObj <| .join [
@@ -38,7 +38,7 @@ index d5c5ba2..b63c5ea 100644
      Json.nonemptyList "sorries" r.sorries,
 @@ -153,7 +153,7 @@ structure ProofStepResponse where
  deriving ToJson, FromJson
-
+ 
  instance : ToJson ProofStepResponse where
 -  toJson r := Json.mkObj <| .flatten [
 +  toJson r := Json.mkObj <| .join [
@@ -55,7 +55,7 @@ index 0b4be3c..61d4e76 100644
    let env ← importModules imports {} 0
 -  return (← env.replay (Std.HashMap.ofList map₂.toList), region)
 +  return (← env.replay (HashMap.ofList map₂.toList), region)
-
+ 
  end Lean.Environment
 diff --git a/REPL/Lean/InfoTree.lean b/REPL/Lean/InfoTree.lean
 index 7abf0b8..d3b28c1 100644
@@ -71,7 +71,7 @@ index 7abf0b8..d3b28c1 100644
 -      (children.toList.map (filter p m)).flatten
 +      (children.toList.map (filter p m)).join
    | .hole mvar => if m mvar then [.hole mvar] else []
-
+ 
  /-- Discard all nodes besides `.context` nodes and `TacticInfo` nodes. -/
 @@ -156,7 +156,7 @@ partial def findAllInfo (t : InfoTree) (ctx? : Option ContextInfo) (p : Info →
    | context ctx t => t.findAllInfo (ctx.mergeIntoOuter? ctx?) p
@@ -81,18 +81,18 @@ index 7abf0b8..d3b28c1 100644
 +    let rest := ts.toList.bind (fun t => t.findAllInfo ctx? p)
      info ++ rest
    | _ => []
-
+ 
 @@ -214,13 +214,13 @@ def sorries (t : InfoTree) : List (ContextInfo × SorryType × Position × Posit
-
+ 
  def tactics (t : InfoTree) : List (ContextInfo × Syntax × List MVarId × Position × Position × Array Name) :=
      -- HACK: creating a child ngen
--  t.findTacticNodes.map fun ⟨i, ctx⟩ =>
--    let range := stxRange ctx.fileMap i.stx
--    ( { ctx with mctx := i.mctxBefore, ngen := ctx.ngen.mkChild.1 },
--      i.stx,
--      i.goalsBefore,
--      range.fst,
--      range.snd,
+-  t.findTacticNodes.map fun ⟨i, ctx⟩ => 
+-    let range := stxRange ctx.fileMap i.stx 
+-    ( { ctx with mctx := i.mctxBefore, ngen := ctx.ngen.mkChild.1 }, 
+-      i.stx, 
+-      i.goalsBefore, 
+-      range.fst, 
+-      range.snd, 
 +  t.findTacticNodes.map fun ⟨i, ctx⟩ =>
 +    let range := stxRange ctx.fileMap i.stx
 +    ( { ctx with mctx := i.mctxBefore, ngen := ctx.ngen.mkChild.1 },
@@ -101,15 +101,15 @@ index 7abf0b8..d3b28c1 100644
 +      range.fst,
 +      range.snd,
        i.getUsedConstantsAsSet.toArray )
-
-
+ 
+ 
 diff --git a/REPL/Main.lean b/REPL/Main.lean
 index a4b97c3..f990b22 100644
 --- a/REPL/Main.lean
 +++ b/REPL/Main.lean
 @@ -95,7 +95,7 @@ def recordProofSnapshot (proofState : ProofSnapshot) : M m Nat := do
    return id
-
+ 
  def sorries (trees : List InfoTree) (env? : Option Environment) : M m (List Sorry) :=
 -  trees.flatMap InfoTree.sorries |>.filter (fun t => match t.2.1 with
 +  trees.bind InfoTree.sorries |>.filter (fun t => match t.2.1 with
@@ -118,7 +118,7 @@ index a4b97c3..f990b22 100644
        fun ⟨ctx, g, pos, endPos⟩ => do
 @@ -117,7 +117,7 @@ def ppTactic (ctx : ContextInfo) (stx : Syntax) : IO Format :=
      pure "<failed to pretty print>"
-
+ 
  def tactics (trees : List InfoTree) : M m (List Tactic) :=
 -  trees.flatMap InfoTree.tactics |>.mapM
 +  trees.bind InfoTree.tactics |>.mapM
@@ -228,9 +228,9 @@ index 070ce3d..4a24ae9 100755
 --- a/test.sh
 +++ b/test.sh
 @@ -41,6 +41,6 @@ for infile in $IN_DIR/*.in; do
-
+ 
  done
-
+ 
 -# Run the Mathlib tests
 -cp lean-toolchain test/Mathlib/
 -cd test/Mathlib/ && ./test.sh
@@ -421,7 +421,7 @@ index 6ec808c..5374db8 100644
 +   "goals": "t : Nat ⊢ Nat",
     "endPos": {"line": 1, "column": 39}}],
   "env": 0}
-
+ 
 diff --git a/test/calc.expected.out b/test/calc.expected.out
 index 94f6a9f..fde8fee 100644
 --- a/test/calc.expected.out
@@ -471,14 +471,14 @@ index b4d885b..557d03b 100644
 +++ b/test/name_generator.expected.out
 @@ -24,13 +24,13 @@
   "goals": []}
-
+ 
  {"traces":
 - ["[Meta.Tactic.simp.rewrite] gt_iff_lt:1000, x > 0 ==> 0 < x",
 + ["[Meta.Tactic.simp.rewrite] @gt_iff_lt:1000, x > 0 ==> 0 < x",
    "[Meta.Tactic.simp.rewrite] h0:1000, 0 < x ==> True"],
   "proofState": 6,
   "goals": []}
-
+ 
  {"traces":
 - ["[Meta.Tactic.simp.rewrite] gt_iff_lt:1000, x > 0 ==> 0 < x",
 + ["[Meta.Tactic.simp.rewrite] @gt_iff_lt:1000, x > 0 ==> 0 < x",
@@ -500,7 +500,7 @@ index 5c89f5a..5be11b7 100644
 +   "endPos": {"line": 3, "column": 7},
 +   "data": "no goals to be solved"}],
   "env": 0}
-
+ 
 diff --git a/test/trace_simp.expected.out b/test/trace_simp.expected.out
 index 2a85844..1f6fbeb 100644
 --- a/test/trace_simp.expected.out
@@ -512,13 +512,14 @@ index 2a85844..1f6fbeb 100644
 -   "[Meta.Tactic.simp.rewrite] f_def:1000, f ==> 37\n[Meta.Tactic.simp.rewrite] eq_self:1000, 37 = 37 ==> True"}],
 +   "[Meta.Tactic.simp.rewrite] f_def:1000, f ==> 37\n[Meta.Tactic.simp.rewrite] @eq_self:1000, 37 = 37 ==> True"}],
   "env": 3}
-
+ 
  {"sorries":
 @@ -28,7 +28,7 @@
-
+ 
  {"traces":
   ["[Meta.Tactic.simp.rewrite] f_def:1000, f ==> 37",
 -  "[Meta.Tactic.simp.rewrite] eq_self:1000, 37 = 37 ==> True"],
 +  "[Meta.Tactic.simp.rewrite] @eq_self:1000, 37 = 37 ==> True"],
   "proofState": 2,
   "goals": []}
+ 

--- a/versions/v4.8.0-rc2.diff
+++ b/versions/v4.8.0-rc2.diff
@@ -11,7 +11,7 @@ index 9cc0914..a2bb150 100644
 +  let trees := s.infoState.trees.toList.drop commandState.infoState.trees.size
 +
 +  pure (s, msgs, trees)
- 
+
  /--
  Process some text input, with or without an existing command state.
 diff --git a/REPL/JSON.lean b/REPL/JSON.lean
@@ -20,7 +20,7 @@ index d5c5ba2..b63c5ea 100644
 +++ b/REPL/JSON.lean
 @@ -83,7 +83,7 @@ structure Sorry where
  deriving FromJson
- 
+
  instance : ToJson Sorry where
 -  toJson r := Json.mkObj <| .flatten [
 +  toJson r := Json.mkObj <| .join [
@@ -29,7 +29,7 @@ index d5c5ba2..b63c5ea 100644
      if r.pos.line ≠ 0 then [("pos", toJson r.pos)] else [],
 @@ -132,7 +132,7 @@ def Json.nonemptyList [ToJson α] (k : String) : List α → List (String × Jso
    | l  => [⟨k, toJson l⟩]
- 
+
  instance : ToJson CommandResponse where
 -  toJson r := Json.mkObj <| .flatten [
 +  toJson r := Json.mkObj <| .join [
@@ -38,7 +38,7 @@ index d5c5ba2..b63c5ea 100644
      Json.nonemptyList "sorries" r.sorries,
 @@ -153,7 +153,7 @@ structure ProofStepResponse where
  deriving ToJson, FromJson
- 
+
  instance : ToJson ProofStepResponse where
 -  toJson r := Json.mkObj <| .flatten [
 +  toJson r := Json.mkObj <| .join [
@@ -55,7 +55,7 @@ index 0b4be3c..61d4e76 100644
    let env ← importModules imports {} 0
 -  return (← env.replay (Std.HashMap.ofList map₂.toList), region)
 +  return (← env.replay (HashMap.ofList map₂.toList), region)
- 
+
  end Lean.Environment
 diff --git a/REPL/Lean/InfoTree.lean b/REPL/Lean/InfoTree.lean
 index 7abf0b8..d3b28c1 100644
@@ -71,7 +71,7 @@ index 7abf0b8..d3b28c1 100644
 -      (children.toList.map (filter p m)).flatten
 +      (children.toList.map (filter p m)).join
    | .hole mvar => if m mvar then [.hole mvar] else []
- 
+
  /-- Discard all nodes besides `.context` nodes and `TacticInfo` nodes. -/
 @@ -156,7 +156,7 @@ partial def findAllInfo (t : InfoTree) (ctx? : Option ContextInfo) (p : Info →
    | context ctx t => t.findAllInfo (ctx.mergeIntoOuter? ctx?) p
@@ -81,18 +81,18 @@ index 7abf0b8..d3b28c1 100644
 +    let rest := ts.toList.bind (fun t => t.findAllInfo ctx? p)
      info ++ rest
    | _ => []
- 
+
 @@ -214,13 +214,13 @@ def sorries (t : InfoTree) : List (ContextInfo × SorryType × Position × Posit
- 
+
  def tactics (t : InfoTree) : List (ContextInfo × Syntax × List MVarId × Position × Position × Array Name) :=
      -- HACK: creating a child ngen
--  t.findTacticNodes.map fun ⟨i, ctx⟩ => 
--    let range := stxRange ctx.fileMap i.stx 
--    ( { ctx with mctx := i.mctxBefore, ngen := ctx.ngen.mkChild.1 }, 
--      i.stx, 
--      i.goalsBefore, 
--      range.fst, 
--      range.snd, 
+-  t.findTacticNodes.map fun ⟨i, ctx⟩ =>
+-    let range := stxRange ctx.fileMap i.stx
+-    ( { ctx with mctx := i.mctxBefore, ngen := ctx.ngen.mkChild.1 },
+-      i.stx,
+-      i.goalsBefore,
+-      range.fst,
+-      range.snd,
 +  t.findTacticNodes.map fun ⟨i, ctx⟩ =>
 +    let range := stxRange ctx.fileMap i.stx
 +    ( { ctx with mctx := i.mctxBefore, ngen := ctx.ngen.mkChild.1 },
@@ -101,15 +101,15 @@ index 7abf0b8..d3b28c1 100644
 +      range.fst,
 +      range.snd,
        i.getUsedConstantsAsSet.toArray )
- 
- 
+
+
 diff --git a/REPL/Main.lean b/REPL/Main.lean
 index a4b97c3..f990b22 100644
 --- a/REPL/Main.lean
 +++ b/REPL/Main.lean
 @@ -95,7 +95,7 @@ def recordProofSnapshot (proofState : ProofSnapshot) : M m Nat := do
    return id
- 
+
  def sorries (trees : List InfoTree) (env? : Option Environment) : M m (List Sorry) :=
 -  trees.flatMap InfoTree.sorries |>.filter (fun t => match t.2.1 with
 +  trees.bind InfoTree.sorries |>.filter (fun t => match t.2.1 with
@@ -118,7 +118,7 @@ index a4b97c3..f990b22 100644
        fun ⟨ctx, g, pos, endPos⟩ => do
 @@ -117,7 +117,7 @@ def ppTactic (ctx : ContextInfo) (stx : Syntax) : IO Format :=
      pure "<failed to pretty print>"
- 
+
  def tactics (trees : List InfoTree) : M m (List Tactic) :=
 -  trees.flatMap InfoTree.tactics |>.mapM
 +  trees.bind InfoTree.tactics |>.mapM
@@ -223,6 +223,20 @@ index 1e70935..78f39e2 100644
 @@ -1 +1 @@
 -leanprover/lean4:v4.14.0
 +leanprover/lean4:v4.8.0-rc2
+diff --git a/test.sh b/test.sh
+index 070ce3d..4a24ae9 100755
+--- a/test.sh
++++ b/test.sh
+@@ -41,6 +41,6 @@ for infile in $IN_DIR/*.in; do
+
+ done
+
+-# Run the Mathlib tests
+-cp lean-toolchain test/Mathlib/
+-cd test/Mathlib/ && ./test.sh
++# Run the Mathlib tests - skipped as it takes too much time
++# cp lean-toolchain test/Mathlib/
++# cd test/Mathlib/ && ./test.sh
 diff --git a/test/Mathlib/lake-manifest.json b/test/Mathlib/lake-manifest.json
 index f312e5a..2c242de 100644
 --- a/test/Mathlib/lake-manifest.json
@@ -407,7 +421,7 @@ index 6ec808c..5374db8 100644
 +   "goals": "t : Nat ⊢ Nat",
     "endPos": {"line": 1, "column": 39}}],
   "env": 0}
- 
+
 diff --git a/test/calc.expected.out b/test/calc.expected.out
 index 94f6a9f..fde8fee 100644
 --- a/test/calc.expected.out
@@ -457,14 +471,14 @@ index b4d885b..557d03b 100644
 +++ b/test/name_generator.expected.out
 @@ -24,13 +24,13 @@
   "goals": []}
- 
+
  {"traces":
 - ["[Meta.Tactic.simp.rewrite] gt_iff_lt:1000, x > 0 ==> 0 < x",
 + ["[Meta.Tactic.simp.rewrite] @gt_iff_lt:1000, x > 0 ==> 0 < x",
    "[Meta.Tactic.simp.rewrite] h0:1000, 0 < x ==> True"],
   "proofState": 6,
   "goals": []}
- 
+
  {"traces":
 - ["[Meta.Tactic.simp.rewrite] gt_iff_lt:1000, x > 0 ==> 0 < x",
 + ["[Meta.Tactic.simp.rewrite] @gt_iff_lt:1000, x > 0 ==> 0 < x",
@@ -486,7 +500,7 @@ index 5c89f5a..5be11b7 100644
 +   "endPos": {"line": 3, "column": 7},
 +   "data": "no goals to be solved"}],
   "env": 0}
- 
+
 diff --git a/test/trace_simp.expected.out b/test/trace_simp.expected.out
 index 2a85844..1f6fbeb 100644
 --- a/test/trace_simp.expected.out
@@ -498,14 +512,13 @@ index 2a85844..1f6fbeb 100644
 -   "[Meta.Tactic.simp.rewrite] f_def:1000, f ==> 37\n[Meta.Tactic.simp.rewrite] eq_self:1000, 37 = 37 ==> True"}],
 +   "[Meta.Tactic.simp.rewrite] f_def:1000, f ==> 37\n[Meta.Tactic.simp.rewrite] @eq_self:1000, 37 = 37 ==> True"}],
   "env": 3}
- 
+
  {"sorries":
 @@ -28,7 +28,7 @@
- 
+
  {"traces":
   ["[Meta.Tactic.simp.rewrite] f_def:1000, f ==> 37",
 -  "[Meta.Tactic.simp.rewrite] eq_self:1000, 37 = 37 ==> True"],
 +  "[Meta.Tactic.simp.rewrite] @eq_self:1000, 37 = 37 ==> True"],
   "proofState": 2,
   "goals": []}
- 

--- a/versions/v4.8.0-rc2.diff
+++ b/versions/v4.8.0-rc2.diff
@@ -179,6 +179,27 @@ index f80f175..7eec48b 100644
   "packagesDir": ".lake/packages",
   "packages": [],
   "name": "REPL",
+diff --git a/lakefile.lean b/lakefile.lean
+new file mode 100644
+index 0000000..33dd0da
+--- /dev/null
++++ b/lakefile.lean
+@@ -0,0 +1,15 @@
++import Lake
++open Lake DSL
++
++package REPL {
++  -- add package configuration options here
++}
++
++lean_lib REPL {
++  -- add library configuration options here
++}
++
++@[default_target]
++lean_exe repl where
++  root := `REPL.Main
++  supportInterpreter := true
 diff --git a/lakefile.toml b/lakefile.toml
 deleted file mode 100644
 index 589e047..0000000
@@ -332,6 +353,23 @@ index f312e5a..2c242de 100644
 +   "configFile": "lakefile.lean"}],
   "name": "«repl-mathlib-tests»",
   "lakeDir": ".lake"}
+diff --git a/test/Mathlib/lakefile.lean b/test/Mathlib/lakefile.lean
+new file mode 100644
+index 0000000..c3dfb14
+--- /dev/null
++++ b/test/Mathlib/lakefile.lean
+@@ -0,0 +1,11 @@
++import Lake
++open Lake DSL
++
++package «repl-mathlib-tests» where
++  -- add package configuration options here
++  require mathlib from git "https://github.com/leanprover-community/mathlib4" @ "v4.8.0-rc2"
++
++@[default_target]
++lean_lib «ReplMathlibTests» where
++  globs := #[.submodules `test]
++  -- add library configuration options here
 diff --git a/test/Mathlib/lakefile.toml b/test/Mathlib/lakefile.toml
 deleted file mode 100644
 index 6ff9631..0000000

--- a/versions/v4.8.0-rc2.diff
+++ b/versions/v4.8.0-rc2.diff
@@ -1,0 +1,473 @@
+diff --git a/REPL/Frontend.lean b/REPL/Frontend.lean
+index 9cc0914..a2bb150 100644
+--- a/REPL/Frontend.lean
++++ b/REPL/Frontend.lean
+@@ -20,7 +20,10 @@ def processCommandsWithInfoTrees
+     (commandState : Command.State) : IO (Command.State × List Message × List InfoTree) := do
+   let commandState := { commandState with infoState.enabled := true }
+   let s ← IO.processCommands inputCtx parserState commandState <&> Frontend.State.commandState
+-  pure (s, s.messages.toList, s.infoState.trees.toList)
++  let msgs := s.messages.toList.drop commandState.messages.toList.length
++  let trees := s.infoState.trees.toList.drop commandState.infoState.trees.size
++
++  pure (s, msgs, trees)
+ 
+ /--
+ Process some text input, with or without an existing command state.
+diff --git a/REPL/JSON.lean b/REPL/JSON.lean
+index d5c5ba2..b63c5ea 100644
+--- a/REPL/JSON.lean
++++ b/REPL/JSON.lean
+@@ -83,7 +83,7 @@ structure Sorry where
+ deriving FromJson
+ 
+ instance : ToJson Sorry where
+-  toJson r := Json.mkObj <| .flatten [
++  toJson r := Json.mkObj <| .join [
+     [("goal", r.goal)],
+     [("proofState", toJson r.proofState)],
+     if r.pos.line ≠ 0 then [("pos", toJson r.pos)] else [],
+@@ -132,7 +132,7 @@ def Json.nonemptyList [ToJson α] (k : String) : List α → List (String × Jso
+   | l  => [⟨k, toJson l⟩]
+ 
+ instance : ToJson CommandResponse where
+-  toJson r := Json.mkObj <| .flatten [
++  toJson r := Json.mkObj <| .join [
+     [("env", r.env)],
+     Json.nonemptyList "messages" r.messages,
+     Json.nonemptyList "sorries" r.sorries,
+@@ -153,7 +153,7 @@ structure ProofStepResponse where
+ deriving ToJson, FromJson
+ 
+ instance : ToJson ProofStepResponse where
+-  toJson r := Json.mkObj <| .flatten [
++  toJson r := Json.mkObj <| .join [
+     [("proofState", r.proofState)],
+     [("goals", toJson r.goals)],
+     Json.nonemptyList "messages" r.messages,
+diff --git a/REPL/Lean/Environment.lean b/REPL/Lean/Environment.lean
+index 0b4be3c..61d4e76 100644
+--- a/REPL/Lean/Environment.lean
++++ b/REPL/Lean/Environment.lean
+@@ -26,6 +26,6 @@ and then replace the new constants.
+ def unpickle (path : FilePath) : IO (Environment × CompactedRegion) := unsafe do
+   let ((imports, map₂), region) ← _root_.unpickle (Array Import × PHashMap Name ConstantInfo) path
+   let env ← importModules imports {} 0
+-  return (← env.replay (Std.HashMap.ofList map₂.toList), region)
++  return (← env.replay (HashMap.ofList map₂.toList), region)
+ 
+ end Lean.Environment
+diff --git a/REPL/Lean/InfoTree.lean b/REPL/Lean/InfoTree.lean
+index 7abf0b8..d3b28c1 100644
+--- a/REPL/Lean/InfoTree.lean
++++ b/REPL/Lean/InfoTree.lean
+@@ -131,9 +131,9 @@ partial def filter (p : Info → Bool) (m : MVarId → Bool := fun _ => false) :
+   | .context ctx tree => tree.filter p m |>.map (.context ctx)
+   | .node info children =>
+     if p info then
+-      [.node info (children.toList.map (filter p m)).flatten.toPArray']
++      [.node info (children.toList.map (filter p m)).join.toPArray']
+     else
+-      (children.toList.map (filter p m)).flatten
++      (children.toList.map (filter p m)).join
+   | .hole mvar => if m mvar then [.hole mvar] else []
+ 
+ /-- Discard all nodes besides `.context` nodes and `TacticInfo` nodes. -/
+@@ -156,7 +156,7 @@ partial def findAllInfo (t : InfoTree) (ctx? : Option ContextInfo) (p : Info →
+   | context ctx t => t.findAllInfo (ctx.mergeIntoOuter? ctx?) p
+   | node i ts  =>
+     let info := if p i then [(i, ctx?)] else []
+-    let rest := ts.toList.flatMap (fun t => t.findAllInfo ctx? p)
++    let rest := ts.toList.bind (fun t => t.findAllInfo ctx? p)
+     info ++ rest
+   | _ => []
+ 
+@@ -214,13 +214,13 @@ def sorries (t : InfoTree) : List (ContextInfo × SorryType × Position × Posit
+ 
+ def tactics (t : InfoTree) : List (ContextInfo × Syntax × List MVarId × Position × Position × Array Name) :=
+     -- HACK: creating a child ngen
+-  t.findTacticNodes.map fun ⟨i, ctx⟩ => 
+-    let range := stxRange ctx.fileMap i.stx 
+-    ( { ctx with mctx := i.mctxBefore, ngen := ctx.ngen.mkChild.1 }, 
+-      i.stx, 
+-      i.goalsBefore, 
+-      range.fst, 
+-      range.snd, 
++  t.findTacticNodes.map fun ⟨i, ctx⟩ =>
++    let range := stxRange ctx.fileMap i.stx
++    ( { ctx with mctx := i.mctxBefore, ngen := ctx.ngen.mkChild.1 },
++      i.stx,
++      i.goalsBefore,
++      range.fst,
++      range.snd,
+       i.getUsedConstantsAsSet.toArray )
+ 
+ 
+diff --git a/REPL/Main.lean b/REPL/Main.lean
+index a4b97c3..f990b22 100644
+--- a/REPL/Main.lean
++++ b/REPL/Main.lean
+@@ -95,7 +95,7 @@ def recordProofSnapshot (proofState : ProofSnapshot) : M m Nat := do
+   return id
+ 
+ def sorries (trees : List InfoTree) (env? : Option Environment) : M m (List Sorry) :=
+-  trees.flatMap InfoTree.sorries |>.filter (fun t => match t.2.1 with
++  trees.bind InfoTree.sorries |>.filter (fun t => match t.2.1 with
+     | .term _ none => false
+     | _ => true ) |>.mapM
+       fun ⟨ctx, g, pos, endPos⟩ => do
+@@ -117,7 +117,7 @@ def ppTactic (ctx : ContextInfo) (stx : Syntax) : IO Format :=
+     pure "<failed to pretty print>"
+ 
+ def tactics (trees : List InfoTree) : M m (List Tactic) :=
+-  trees.flatMap InfoTree.tactics |>.mapM
++  trees.bind InfoTree.tactics |>.mapM
+     fun ⟨ctx, stx, goals, pos, endPos, ns⟩ => do
+       let proofState := some (← ProofSnapshot.create ctx none none goals)
+       let goals := s!"{(← ctx.ppGoals goals)}".trim
+@@ -213,14 +213,13 @@ def runCommand (s : Command) : M IO (CommandResponse ⊕ Error) := do
+       { fileName := "",
+         fileMap := default,
+         tacticCache? := none,
+-        snap? := none,
+-        cancelTk? := none } }
++        snap? := none } }
+   let env ← recordCommandSnapshot cmdSnapshot
+   let jsonTrees := match s.infotree with
+   | some "full" => trees
+-  | some "tactics" => trees.flatMap InfoTree.retainTacticInfo
+-  | some "original" => trees.flatMap InfoTree.retainTacticInfo |>.flatMap InfoTree.retainOriginal
+-  | some "substantive" => trees.flatMap InfoTree.retainTacticInfo |>.flatMap InfoTree.retainSubstantive
++  | some "tactics" => trees.bind InfoTree.retainTacticInfo
++  | some "original" => trees.bind InfoTree.retainTacticInfo |>.bind InfoTree.retainOriginal
++  | some "substantive" => trees.bind InfoTree.retainTacticInfo |>.bind InfoTree.retainSubstantive
+   | _ => []
+   let infotree ← if jsonTrees.isEmpty then
+     pure none
+diff --git a/REPL/Snapshots.lean b/REPL/Snapshots.lean
+index 1114c24..7462141 100644
+--- a/REPL/Snapshots.lean
++++ b/REPL/Snapshots.lean
+@@ -83,7 +83,7 @@ def unpickle (path : FilePath) : IO (CommandSnapshot × CompactedRegion) := unsa
+   let ((imports, map₂, cmdState, cmdContext), region) ←
+     _root_.unpickle (Array Import × PHashMap Name ConstantInfo × CompactableCommandSnapshot ×
+       Command.Context) path
+-  let env ← (← importModules imports {} 0).replay (Std.HashMap.ofList map₂.toList)
++  let env ← (← importModules imports {} 0).replay (HashMap.ofList map₂.toList)
+   let p' : CommandSnapshot :=
+   { cmdState := { cmdState with env }
+     cmdContext }
+@@ -284,9 +284,9 @@ def unpickle (path : FilePath) (cmd? : Option CommandSnapshot) :
+   let env ← match cmd? with
+   | none =>
+     enableInitializersExecution
+-    (← importModules imports {} 0).replay (Std.HashMap.ofList map₂.toList)
++    (← importModules imports {} 0).replay (HashMap.ofList map₂.toList)
+   | some cmd =>
+-    cmd.cmdState.env.replay (Std.HashMap.ofList map₂.toList)
++    cmd.cmdState.env.replay (HashMap.ofList map₂.toList)
+   let p' : ProofSnapshot :=
+   { coreState := { coreState with env }
+     coreContext
+diff --git a/lake-manifest.json b/lake-manifest.json
+index f80f175..7eec48b 100644
+--- a/lake-manifest.json
++++ b/lake-manifest.json
+@@ -1,4 +1,4 @@
+-{"version": "1.1.0",
++{"version": 7,
+  "packagesDir": ".lake/packages",
+  "packages": [],
+  "name": "REPL",
+diff --git a/lakefile.toml b/lakefile.toml
+deleted file mode 100644
+index 589e047..0000000
+--- a/lakefile.toml
++++ /dev/null
+@@ -1,10 +0,0 @@
+-name = "REPL"
+-defaultTargets = ["repl"]
+-
+-[[lean_lib]]
+-name = "REPL"
+-
+-[[lean_exe]]
+-name = "repl"
+-root = "REPL.Main"
+-supportInterpreter = true
+diff --git a/lean-toolchain b/lean-toolchain
+index 1e70935..78f39e2 100644
+--- a/lean-toolchain
++++ b/lean-toolchain
+@@ -1 +1 @@
+-leanprover/lean4:v4.14.0
++leanprover/lean4:v4.8.0-rc2
+diff --git a/test/Mathlib/lake-manifest.json b/test/Mathlib/lake-manifest.json
+index f312e5a..2c242de 100644
+--- a/test/Mathlib/lake-manifest.json
++++ b/test/Mathlib/lake-manifest.json
+@@ -1,95 +1,68 @@
+-{"version": "1.1.0",
++{"version": 7,
+  "packagesDir": ".lake/packages",
+  "packages":
+- [{"url": "https://github.com/leanprover-community/mathlib4",
++ [{"url": "https://github.com/leanprover-community/batteries",
+    "type": "git",
+    "subDir": null,
+-   "scope": "",
+-   "rev": "4bbdccd9c5f862bf90ff12f0a9e2c8be032b9a84",
+-   "name": "mathlib",
+-   "manifestFile": "lake-manifest.json",
+-   "inputRev": "v4.14.0",
+-   "inherited": false,
+-   "configFile": "lakefile.lean"},
+-  {"url": "https://github.com/leanprover-community/plausible",
+-   "type": "git",
+-   "subDir": null,
+-   "scope": "leanprover-community",
+-   "rev": "42dc02bdbc5d0c2f395718462a76c3d87318f7fa",
+-   "name": "plausible",
++   "rev": "551ff2d7dffd7af914cdbd01abbd449fe3e3d428",
++   "name": "batteries",
+    "manifestFile": "lake-manifest.json",
+    "inputRev": "main",
+    "inherited": true,
+-   "configFile": "lakefile.toml"},
+-  {"url": "https://github.com/leanprover-community/LeanSearchClient",
++   "configFile": "lakefile.lean"},
++  {"url": "https://github.com/leanprover-community/quote4",
+    "type": "git",
+    "subDir": null,
+-   "scope": "leanprover-community",
+-   "rev": "d7caecce0d0f003fd5e9cce9a61f1dd6ba83142b",
+-   "name": "LeanSearchClient",
++   "rev": "53156671405fbbd5402ed17a79bd129b961bd8d6",
++   "name": "Qq",
+    "manifestFile": "lake-manifest.json",
+-   "inputRev": "main",
++   "inputRev": "master",
+    "inherited": true,
+-   "configFile": "lakefile.toml"},
+-  {"url": "https://github.com/leanprover-community/import-graph",
++   "configFile": "lakefile.lean"},
++  {"url": "https://github.com/leanprover-community/aesop",
+    "type": "git",
+    "subDir": null,
+-   "scope": "leanprover-community",
+-   "rev": "519e509a28864af5bed98033dd33b95cf08e9aa7",
+-   "name": "importGraph",
++   "rev": "53ba96ad7666d4a2515292974631629b5ea5dfee",
++   "name": "aesop",
+    "manifestFile": "lake-manifest.json",
+-   "inputRev": "v4.14.0",
++   "inputRev": "master",
+    "inherited": true,
+    "configFile": "lakefile.toml"},
+   {"url": "https://github.com/leanprover-community/ProofWidgets4",
+    "type": "git",
+    "subDir": null,
+-   "scope": "leanprover-community",
+-   "rev": "68280daef58803f68368eb2e53046dabcd270c9d",
++   "rev": "e6b6247c61280c77ade6bbf0bc3c66a44fe2e0c5",
+    "name": "proofwidgets",
+    "manifestFile": "lake-manifest.json",
+-   "inputRev": "v0.0.47",
++   "inputRev": "v0.0.36",
+    "inherited": true,
+    "configFile": "lakefile.lean"},
+-  {"url": "https://github.com/leanprover-community/aesop",
+-   "type": "git",
+-   "subDir": null,
+-   "scope": "leanprover-community",
+-   "rev": "5a0ec8588855265ade536f35bcdcf0fb24fd6030",
+-   "name": "aesop",
+-   "manifestFile": "lake-manifest.json",
+-   "inputRev": "v4.14.0",
+-   "inherited": true,
+-   "configFile": "lakefile.toml"},
+-  {"url": "https://github.com/leanprover-community/quote4",
++  {"url": "https://github.com/leanprover/lean4-cli",
+    "type": "git",
+    "subDir": null,
+-   "scope": "leanprover-community",
+-   "rev": "303b23fbcea94ac4f96e590c1cad6618fd4f5f41",
+-   "name": "Qq",
++   "rev": "a11566029bd9ec4f68a65394e8c3ff1af74c1a29",
++   "name": "Cli",
+    "manifestFile": "lake-manifest.json",
+-   "inputRev": "master",
++   "inputRev": "main",
+    "inherited": true,
+    "configFile": "lakefile.lean"},
+-  {"url": "https://github.com/leanprover-community/batteries",
++  {"url": "https://github.com/leanprover-community/import-graph.git",
+    "type": "git",
+    "subDir": null,
+-   "scope": "leanprover-community",
+-   "rev": "8d6c853f11a5172efa0e96b9f2be1a83d861cdd9",
+-   "name": "batteries",
++   "rev": "77e081815b30b0d30707e1c5b0c6a6761f7a2404",
++   "name": "importGraph",
+    "manifestFile": "lake-manifest.json",
+-   "inputRev": "v4.14.0",
++   "inputRev": "main",
+    "inherited": true,
+    "configFile": "lakefile.toml"},
+-  {"url": "https://github.com/leanprover/lean4-cli",
++  {"url": "https://github.com/leanprover-community/mathlib4",
+    "type": "git",
+    "subDir": null,
+-   "scope": "leanprover",
+-   "rev": "726b3c9ad13acca724d4651f14afc4804a7b0e4d",
+-   "name": "Cli",
++   "rev": "b5eba595428809e96f3ed113bc7ba776c5f801ac",
++   "name": "mathlib",
+    "manifestFile": "lake-manifest.json",
+-   "inputRev": "main",
+-   "inherited": true,
+-   "configFile": "lakefile.toml"}],
++   "inputRev": "v4.8.0",
++   "inherited": false,
++   "configFile": "lakefile.lean"}],
+  "name": "«repl-mathlib-tests»",
+  "lakeDir": ".lake"}
+diff --git a/test/Mathlib/lakefile.toml b/test/Mathlib/lakefile.toml
+deleted file mode 100644
+index 6ff9631..0000000
+--- a/test/Mathlib/lakefile.toml
++++ /dev/null
+@@ -1,11 +0,0 @@
+-name = "«repl-mathlib-tests»"
+-defaultTargets = ["ReplMathlibTests"]
+-
+-[[require]]
+-name = "mathlib"
+-git = "https://github.com/leanprover-community/mathlib4"
+-rev = "v4.14.0"
+-
+-[[lean_lib]]
+-name = "ReplMathlibTests"
+-globs = ["test.+"]
+diff --git a/test/Mathlib/lean-toolchain b/test/Mathlib/lean-toolchain
+index 401bc14..78f39e2 100644
+--- a/test/Mathlib/lean-toolchain
++++ b/test/Mathlib/lean-toolchain
+@@ -1 +1 @@
+-leanprover/lean4:v4.14.0
+\ No newline at end of file
++leanprover/lean4:v4.8.0-rc2
+diff --git a/test/all_tactics.expected.out b/test/all_tactics.expected.out
+index 6ec808c..5374db8 100644
+--- a/test/all_tactics.expected.out
++++ b/test/all_tactics.expected.out
+@@ -9,7 +9,7 @@
+    "tactic": "exact t",
+    "proofState": 1,
+    "pos": {"line": 1, "column": 32},
+-   "goals": "t : Nat\n⊢ Nat",
++   "goals": "t : Nat ⊢ Nat",
+    "endPos": {"line": 1, "column": 39}}],
+  "env": 0}
+ 
+diff --git a/test/calc.expected.out b/test/calc.expected.out
+index 94f6a9f..fde8fee 100644
+--- a/test/calc.expected.out
++++ b/test/calc.expected.out
+@@ -1,35 +1,22 @@
+ {"tactics":
+  [{"usedConstants":
+-   ["Trans.trans",
+-    "sorryAx",
+-    "instOfNatNat",
+-    "instTransEq",
+-    "Nat",
+-    "OfNat.ofNat",
+-    "Bool.false",
+-    "Eq"],
++   ["Trans.trans", "instOfNatNat", "instTransEq", "Nat", "OfNat.ofNat", "Eq"],
+    "tactic": "calc\n  3 = 4 := by sorry\n  4 = 5 := by sorry",
+    "proofState": 2,
+    "pos": {"line": 1, "column": 22},
+    "goals": "⊢ 3 = 5",
+    "endPos": {"line": 3, "column": 19}},
+-  {"usedConstants": [],
+-   "tactic": "\n  3 = 4 := by sorry\n  4 = 5 := by sorry",
+-   "proofState": 3,
+-   "pos": {"line": 2, "column": 2},
+-   "goals": "no goals",
+-   "endPos": {"line": 3, "column": 19}},
+   {"usedConstants":
+    ["sorryAx", "instOfNatNat", "Nat", "OfNat.ofNat", "Bool.false", "Eq"],
+    "tactic": "sorry",
+-   "proofState": 4,
++   "proofState": 3,
+    "pos": {"line": 2, "column": 14},
+    "goals": "⊢ 3 = 4",
+    "endPos": {"line": 2, "column": 19}},
+   {"usedConstants":
+    ["sorryAx", "instOfNatNat", "Nat", "OfNat.ofNat", "Bool.false", "Eq"],
+    "tactic": "sorry",
+-   "proofState": 5,
++   "proofState": 4,
+    "pos": {"line": 3, "column": 14},
+    "goals": "⊢ 4 = 5",
+    "endPos": {"line": 3, "column": 19}}],
+diff --git a/test/name_generator.expected.out b/test/name_generator.expected.out
+index b4d885b..557d03b 100644
+--- a/test/name_generator.expected.out
++++ b/test/name_generator.expected.out
+@@ -24,13 +24,13 @@
+  "goals": []}
+ 
+ {"traces":
+- ["[Meta.Tactic.simp.rewrite] gt_iff_lt:1000, x > 0 ==> 0 < x",
++ ["[Meta.Tactic.simp.rewrite] @gt_iff_lt:1000, x > 0 ==> 0 < x",
+   "[Meta.Tactic.simp.rewrite] h0:1000, 0 < x ==> True"],
+  "proofState": 6,
+  "goals": []}
+ 
+ {"traces":
+- ["[Meta.Tactic.simp.rewrite] gt_iff_lt:1000, x > 0 ==> 0 < x",
++ ["[Meta.Tactic.simp.rewrite] @gt_iff_lt:1000, x > 0 ==> 0 < x",
+   "[Meta.Tactic.simp.rewrite] h0:1000, 0 < x ==> True"],
+  "proofState": 7,
+  "goals": []}
+diff --git a/test/no_goal_sorry.expected.out b/test/no_goal_sorry.expected.out
+index 5c89f5a..5be11b7 100644
+--- a/test/no_goal_sorry.expected.out
++++ b/test/no_goal_sorry.expected.out
+@@ -4,8 +4,8 @@
+    "endPos": {"line": 2, "column": 18},
+    "data": "type expected, got\n  (set Nat : ?m.8 PUnit)"},
+   {"severity": "error",
+-   "pos": {"line": 2, "column": 22},
+-   "endPos": {"line": 2, "column": 24},
+-   "data": "Case tag 'body' not found.\n\nThere are no cases to select."}],
++   "pos": {"line": 3, "column": 2},
++   "endPos": {"line": 3, "column": 7},
++   "data": "no goals to be solved"}],
+  "env": 0}
+ 
+diff --git a/test/trace_simp.expected.out b/test/trace_simp.expected.out
+index 2a85844..1f6fbeb 100644
+--- a/test/trace_simp.expected.out
++++ b/test/trace_simp.expected.out
+@@ -9,7 +9,7 @@
+    "pos": {"line": 1, "column": 23},
+    "endPos": {"line": 1, "column": 27},
+    "data":
+-   "[Meta.Tactic.simp.rewrite] f_def:1000, f ==> 37\n[Meta.Tactic.simp.rewrite] eq_self:1000, 37 = 37 ==> True"}],
++   "[Meta.Tactic.simp.rewrite] f_def:1000, f ==> 37\n[Meta.Tactic.simp.rewrite] @eq_self:1000, 37 = 37 ==> True"}],
+  "env": 3}
+ 
+ {"sorries":
+@@ -28,7 +28,7 @@
+ 
+ {"traces":
+  ["[Meta.Tactic.simp.rewrite] f_def:1000, f ==> 37",
+-  "[Meta.Tactic.simp.rewrite] eq_self:1000, 37 = 37 ==> True"],
++  "[Meta.Tactic.simp.rewrite] @eq_self:1000, 37 = 37 ==> True"],
+  "proofState": 2,
+  "goals": []}
+ 

--- a/versions/v4.8.0.diff
+++ b/versions/v4.8.0.diff
@@ -1,0 +1,511 @@
+diff --git a/REPL/Frontend.lean b/REPL/Frontend.lean
+index 9cc0914..a2bb150 100644
+--- a/REPL/Frontend.lean
++++ b/REPL/Frontend.lean
+@@ -20,7 +20,10 @@ def processCommandsWithInfoTrees
+     (commandState : Command.State) : IO (Command.State × List Message × List InfoTree) := do
+   let commandState := { commandState with infoState.enabled := true }
+   let s ← IO.processCommands inputCtx parserState commandState <&> Frontend.State.commandState
+-  pure (s, s.messages.toList, s.infoState.trees.toList)
++  let msgs := s.messages.toList.drop commandState.messages.toList.length
++  let trees := s.infoState.trees.toList.drop commandState.infoState.trees.size
++
++  pure (s, msgs, trees)
+ 
+ /--
+ Process some text input, with or without an existing command state.
+diff --git a/REPL/JSON.lean b/REPL/JSON.lean
+index d5c5ba2..b63c5ea 100644
+--- a/REPL/JSON.lean
++++ b/REPL/JSON.lean
+@@ -83,7 +83,7 @@ structure Sorry where
+ deriving FromJson
+ 
+ instance : ToJson Sorry where
+-  toJson r := Json.mkObj <| .flatten [
++  toJson r := Json.mkObj <| .join [
+     [("goal", r.goal)],
+     [("proofState", toJson r.proofState)],
+     if r.pos.line ≠ 0 then [("pos", toJson r.pos)] else [],
+@@ -132,7 +132,7 @@ def Json.nonemptyList [ToJson α] (k : String) : List α → List (String × Jso
+   | l  => [⟨k, toJson l⟩]
+ 
+ instance : ToJson CommandResponse where
+-  toJson r := Json.mkObj <| .flatten [
++  toJson r := Json.mkObj <| .join [
+     [("env", r.env)],
+     Json.nonemptyList "messages" r.messages,
+     Json.nonemptyList "sorries" r.sorries,
+@@ -153,7 +153,7 @@ structure ProofStepResponse where
+ deriving ToJson, FromJson
+ 
+ instance : ToJson ProofStepResponse where
+-  toJson r := Json.mkObj <| .flatten [
++  toJson r := Json.mkObj <| .join [
+     [("proofState", r.proofState)],
+     [("goals", toJson r.goals)],
+     Json.nonemptyList "messages" r.messages,
+diff --git a/REPL/Lean/Environment.lean b/REPL/Lean/Environment.lean
+index 0b4be3c..61d4e76 100644
+--- a/REPL/Lean/Environment.lean
++++ b/REPL/Lean/Environment.lean
+@@ -26,6 +26,6 @@ and then replace the new constants.
+ def unpickle (path : FilePath) : IO (Environment × CompactedRegion) := unsafe do
+   let ((imports, map₂), region) ← _root_.unpickle (Array Import × PHashMap Name ConstantInfo) path
+   let env ← importModules imports {} 0
+-  return (← env.replay (Std.HashMap.ofList map₂.toList), region)
++  return (← env.replay (HashMap.ofList map₂.toList), region)
+ 
+ end Lean.Environment
+diff --git a/REPL/Lean/InfoTree.lean b/REPL/Lean/InfoTree.lean
+index 7abf0b8..d3b28c1 100644
+--- a/REPL/Lean/InfoTree.lean
++++ b/REPL/Lean/InfoTree.lean
+@@ -131,9 +131,9 @@ partial def filter (p : Info → Bool) (m : MVarId → Bool := fun _ => false) :
+   | .context ctx tree => tree.filter p m |>.map (.context ctx)
+   | .node info children =>
+     if p info then
+-      [.node info (children.toList.map (filter p m)).flatten.toPArray']
++      [.node info (children.toList.map (filter p m)).join.toPArray']
+     else
+-      (children.toList.map (filter p m)).flatten
++      (children.toList.map (filter p m)).join
+   | .hole mvar => if m mvar then [.hole mvar] else []
+ 
+ /-- Discard all nodes besides `.context` nodes and `TacticInfo` nodes. -/
+@@ -156,7 +156,7 @@ partial def findAllInfo (t : InfoTree) (ctx? : Option ContextInfo) (p : Info →
+   | context ctx t => t.findAllInfo (ctx.mergeIntoOuter? ctx?) p
+   | node i ts  =>
+     let info := if p i then [(i, ctx?)] else []
+-    let rest := ts.toList.flatMap (fun t => t.findAllInfo ctx? p)
++    let rest := ts.toList.bind (fun t => t.findAllInfo ctx? p)
+     info ++ rest
+   | _ => []
+ 
+@@ -214,13 +214,13 @@ def sorries (t : InfoTree) : List (ContextInfo × SorryType × Position × Posit
+ 
+ def tactics (t : InfoTree) : List (ContextInfo × Syntax × List MVarId × Position × Position × Array Name) :=
+     -- HACK: creating a child ngen
+-  t.findTacticNodes.map fun ⟨i, ctx⟩ => 
+-    let range := stxRange ctx.fileMap i.stx 
+-    ( { ctx with mctx := i.mctxBefore, ngen := ctx.ngen.mkChild.1 }, 
+-      i.stx, 
+-      i.goalsBefore, 
+-      range.fst, 
+-      range.snd, 
++  t.findTacticNodes.map fun ⟨i, ctx⟩ =>
++    let range := stxRange ctx.fileMap i.stx
++    ( { ctx with mctx := i.mctxBefore, ngen := ctx.ngen.mkChild.1 },
++      i.stx,
++      i.goalsBefore,
++      range.fst,
++      range.snd,
+       i.getUsedConstantsAsSet.toArray )
+ 
+ 
+diff --git a/REPL/Main.lean b/REPL/Main.lean
+index a4b97c3..f990b22 100644
+--- a/REPL/Main.lean
++++ b/REPL/Main.lean
+@@ -95,7 +95,7 @@ def recordProofSnapshot (proofState : ProofSnapshot) : M m Nat := do
+   return id
+ 
+ def sorries (trees : List InfoTree) (env? : Option Environment) : M m (List Sorry) :=
+-  trees.flatMap InfoTree.sorries |>.filter (fun t => match t.2.1 with
++  trees.bind InfoTree.sorries |>.filter (fun t => match t.2.1 with
+     | .term _ none => false
+     | _ => true ) |>.mapM
+       fun ⟨ctx, g, pos, endPos⟩ => do
+@@ -117,7 +117,7 @@ def ppTactic (ctx : ContextInfo) (stx : Syntax) : IO Format :=
+     pure "<failed to pretty print>"
+ 
+ def tactics (trees : List InfoTree) : M m (List Tactic) :=
+-  trees.flatMap InfoTree.tactics |>.mapM
++  trees.bind InfoTree.tactics |>.mapM
+     fun ⟨ctx, stx, goals, pos, endPos, ns⟩ => do
+       let proofState := some (← ProofSnapshot.create ctx none none goals)
+       let goals := s!"{(← ctx.ppGoals goals)}".trim
+@@ -213,14 +213,13 @@ def runCommand (s : Command) : M IO (CommandResponse ⊕ Error) := do
+       { fileName := "",
+         fileMap := default,
+         tacticCache? := none,
+-        snap? := none,
+-        cancelTk? := none } }
++        snap? := none } }
+   let env ← recordCommandSnapshot cmdSnapshot
+   let jsonTrees := match s.infotree with
+   | some "full" => trees
+-  | some "tactics" => trees.flatMap InfoTree.retainTacticInfo
+-  | some "original" => trees.flatMap InfoTree.retainTacticInfo |>.flatMap InfoTree.retainOriginal
+-  | some "substantive" => trees.flatMap InfoTree.retainTacticInfo |>.flatMap InfoTree.retainSubstantive
++  | some "tactics" => trees.bind InfoTree.retainTacticInfo
++  | some "original" => trees.bind InfoTree.retainTacticInfo |>.bind InfoTree.retainOriginal
++  | some "substantive" => trees.bind InfoTree.retainTacticInfo |>.bind InfoTree.retainSubstantive
+   | _ => []
+   let infotree ← if jsonTrees.isEmpty then
+     pure none
+diff --git a/REPL/Snapshots.lean b/REPL/Snapshots.lean
+index 1114c24..7462141 100644
+--- a/REPL/Snapshots.lean
++++ b/REPL/Snapshots.lean
+@@ -83,7 +83,7 @@ def unpickle (path : FilePath) : IO (CommandSnapshot × CompactedRegion) := unsa
+   let ((imports, map₂, cmdState, cmdContext), region) ←
+     _root_.unpickle (Array Import × PHashMap Name ConstantInfo × CompactableCommandSnapshot ×
+       Command.Context) path
+-  let env ← (← importModules imports {} 0).replay (Std.HashMap.ofList map₂.toList)
++  let env ← (← importModules imports {} 0).replay (HashMap.ofList map₂.toList)
+   let p' : CommandSnapshot :=
+   { cmdState := { cmdState with env }
+     cmdContext }
+@@ -284,9 +284,9 @@ def unpickle (path : FilePath) (cmd? : Option CommandSnapshot) :
+   let env ← match cmd? with
+   | none =>
+     enableInitializersExecution
+-    (← importModules imports {} 0).replay (Std.HashMap.ofList map₂.toList)
++    (← importModules imports {} 0).replay (HashMap.ofList map₂.toList)
+   | some cmd =>
+-    cmd.cmdState.env.replay (Std.HashMap.ofList map₂.toList)
++    cmd.cmdState.env.replay (HashMap.ofList map₂.toList)
+   let p' : ProofSnapshot :=
+   { coreState := { coreState with env }
+     coreContext
+diff --git a/lake-manifest.json b/lake-manifest.json
+index f80f175..7eec48b 100644
+--- a/lake-manifest.json
++++ b/lake-manifest.json
+@@ -1,4 +1,4 @@
+-{"version": "1.1.0",
++{"version": 7,
+  "packagesDir": ".lake/packages",
+  "packages": [],
+  "name": "REPL",
+diff --git a/lakefile.lean b/lakefile.lean
+new file mode 100644
+index 0000000..33dd0da
+--- /dev/null
++++ b/lakefile.lean
+@@ -0,0 +1,15 @@
++import Lake
++open Lake DSL
++
++package REPL {
++  -- add package configuration options here
++}
++
++lean_lib REPL {
++  -- add library configuration options here
++}
++
++@[default_target]
++lean_exe repl where
++  root := `REPL.Main
++  supportInterpreter := true
+diff --git a/lakefile.toml b/lakefile.toml
+deleted file mode 100644
+index 589e047..0000000
+--- a/lakefile.toml
++++ /dev/null
+@@ -1,10 +0,0 @@
+-name = "REPL"
+-defaultTargets = ["repl"]
+-
+-[[lean_lib]]
+-name = "REPL"
+-
+-[[lean_exe]]
+-name = "repl"
+-root = "REPL.Main"
+-supportInterpreter = true
+diff --git a/lean-toolchain b/lean-toolchain
+index 1e70935..ef1f67e 100644
+--- a/lean-toolchain
++++ b/lean-toolchain
+@@ -1 +1 @@
+-leanprover/lean4:v4.14.0
++leanprover/lean4:v4.8.0
+diff --git a/test/Mathlib/lake-manifest.json b/test/Mathlib/lake-manifest.json
+index f312e5a..2c242de 100644
+--- a/test/Mathlib/lake-manifest.json
++++ b/test/Mathlib/lake-manifest.json
+@@ -1,95 +1,68 @@
+-{"version": "1.1.0",
++{"version": 7,
+  "packagesDir": ".lake/packages",
+  "packages":
+- [{"url": "https://github.com/leanprover-community/mathlib4",
++ [{"url": "https://github.com/leanprover-community/batteries",
+    "type": "git",
+    "subDir": null,
+-   "scope": "",
+-   "rev": "4bbdccd9c5f862bf90ff12f0a9e2c8be032b9a84",
+-   "name": "mathlib",
+-   "manifestFile": "lake-manifest.json",
+-   "inputRev": "v4.14.0",
+-   "inherited": false,
+-   "configFile": "lakefile.lean"},
+-  {"url": "https://github.com/leanprover-community/plausible",
+-   "type": "git",
+-   "subDir": null,
+-   "scope": "leanprover-community",
+-   "rev": "42dc02bdbc5d0c2f395718462a76c3d87318f7fa",
+-   "name": "plausible",
++   "rev": "551ff2d7dffd7af914cdbd01abbd449fe3e3d428",
++   "name": "batteries",
+    "manifestFile": "lake-manifest.json",
+    "inputRev": "main",
+    "inherited": true,
+-   "configFile": "lakefile.toml"},
+-  {"url": "https://github.com/leanprover-community/LeanSearchClient",
++   "configFile": "lakefile.lean"},
++  {"url": "https://github.com/leanprover-community/quote4",
+    "type": "git",
+    "subDir": null,
+-   "scope": "leanprover-community",
+-   "rev": "d7caecce0d0f003fd5e9cce9a61f1dd6ba83142b",
+-   "name": "LeanSearchClient",
++   "rev": "53156671405fbbd5402ed17a79bd129b961bd8d6",
++   "name": "Qq",
+    "manifestFile": "lake-manifest.json",
+-   "inputRev": "main",
++   "inputRev": "master",
+    "inherited": true,
+-   "configFile": "lakefile.toml"},
+-  {"url": "https://github.com/leanprover-community/import-graph",
++   "configFile": "lakefile.lean"},
++  {"url": "https://github.com/leanprover-community/aesop",
+    "type": "git",
+    "subDir": null,
+-   "scope": "leanprover-community",
+-   "rev": "519e509a28864af5bed98033dd33b95cf08e9aa7",
+-   "name": "importGraph",
++   "rev": "53ba96ad7666d4a2515292974631629b5ea5dfee",
++   "name": "aesop",
+    "manifestFile": "lake-manifest.json",
+-   "inputRev": "v4.14.0",
++   "inputRev": "master",
+    "inherited": true,
+    "configFile": "lakefile.toml"},
+   {"url": "https://github.com/leanprover-community/ProofWidgets4",
+    "type": "git",
+    "subDir": null,
+-   "scope": "leanprover-community",
+-   "rev": "68280daef58803f68368eb2e53046dabcd270c9d",
++   "rev": "e6b6247c61280c77ade6bbf0bc3c66a44fe2e0c5",
+    "name": "proofwidgets",
+    "manifestFile": "lake-manifest.json",
+-   "inputRev": "v0.0.47",
++   "inputRev": "v0.0.36",
+    "inherited": true,
+    "configFile": "lakefile.lean"},
+-  {"url": "https://github.com/leanprover-community/aesop",
+-   "type": "git",
+-   "subDir": null,
+-   "scope": "leanprover-community",
+-   "rev": "5a0ec8588855265ade536f35bcdcf0fb24fd6030",
+-   "name": "aesop",
+-   "manifestFile": "lake-manifest.json",
+-   "inputRev": "v4.14.0",
+-   "inherited": true,
+-   "configFile": "lakefile.toml"},
+-  {"url": "https://github.com/leanprover-community/quote4",
++  {"url": "https://github.com/leanprover/lean4-cli",
+    "type": "git",
+    "subDir": null,
+-   "scope": "leanprover-community",
+-   "rev": "303b23fbcea94ac4f96e590c1cad6618fd4f5f41",
+-   "name": "Qq",
++   "rev": "a11566029bd9ec4f68a65394e8c3ff1af74c1a29",
++   "name": "Cli",
+    "manifestFile": "lake-manifest.json",
+-   "inputRev": "master",
++   "inputRev": "main",
+    "inherited": true,
+    "configFile": "lakefile.lean"},
+-  {"url": "https://github.com/leanprover-community/batteries",
++  {"url": "https://github.com/leanprover-community/import-graph.git",
+    "type": "git",
+    "subDir": null,
+-   "scope": "leanprover-community",
+-   "rev": "8d6c853f11a5172efa0e96b9f2be1a83d861cdd9",
+-   "name": "batteries",
++   "rev": "77e081815b30b0d30707e1c5b0c6a6761f7a2404",
++   "name": "importGraph",
+    "manifestFile": "lake-manifest.json",
+-   "inputRev": "v4.14.0",
++   "inputRev": "main",
+    "inherited": true,
+    "configFile": "lakefile.toml"},
+-  {"url": "https://github.com/leanprover/lean4-cli",
++  {"url": "https://github.com/leanprover-community/mathlib4",
+    "type": "git",
+    "subDir": null,
+-   "scope": "leanprover",
+-   "rev": "726b3c9ad13acca724d4651f14afc4804a7b0e4d",
+-   "name": "Cli",
++   "rev": "b5eba595428809e96f3ed113bc7ba776c5f801ac",
++   "name": "mathlib",
+    "manifestFile": "lake-manifest.json",
+-   "inputRev": "main",
+-   "inherited": true,
+-   "configFile": "lakefile.toml"}],
++   "inputRev": "v4.8.0",
++   "inherited": false,
++   "configFile": "lakefile.lean"}],
+  "name": "«repl-mathlib-tests»",
+  "lakeDir": ".lake"}
+diff --git a/test/Mathlib/lakefile.lean b/test/Mathlib/lakefile.lean
+new file mode 100644
+index 0000000..c3dfb14
+--- /dev/null
++++ b/test/Mathlib/lakefile.lean
+@@ -0,0 +1,11 @@
++import Lake
++open Lake DSL
++
++package «repl-mathlib-tests» where
++  -- add package configuration options here
++  require mathlib from git "https://github.com/leanprover-community/mathlib4" @ "v4.8.0"
++
++@[default_target]
++lean_lib «ReplMathlibTests» where
++  globs := #[.submodules `test]
++  -- add library configuration options here
+diff --git a/test/Mathlib/lakefile.toml b/test/Mathlib/lakefile.toml
+deleted file mode 100644
+index 6ff9631..0000000
+--- a/test/Mathlib/lakefile.toml
++++ /dev/null
+@@ -1,11 +0,0 @@
+-name = "«repl-mathlib-tests»"
+-defaultTargets = ["ReplMathlibTests"]
+-
+-[[require]]
+-name = "mathlib"
+-git = "https://github.com/leanprover-community/mathlib4"
+-rev = "v4.14.0"
+-
+-[[lean_lib]]
+-name = "ReplMathlibTests"
+-globs = ["test.+"]
+diff --git a/test/Mathlib/lean-toolchain b/test/Mathlib/lean-toolchain
+index 401bc14..ef1f67e 100644
+--- a/test/Mathlib/lean-toolchain
++++ b/test/Mathlib/lean-toolchain
+@@ -1 +1 @@
+-leanprover/lean4:v4.14.0
+\ No newline at end of file
++leanprover/lean4:v4.8.0
+diff --git a/test/all_tactics.expected.out b/test/all_tactics.expected.out
+index 6ec808c..5374db8 100644
+--- a/test/all_tactics.expected.out
++++ b/test/all_tactics.expected.out
+@@ -9,7 +9,7 @@
+    "tactic": "exact t",
+    "proofState": 1,
+    "pos": {"line": 1, "column": 32},
+-   "goals": "t : Nat\n⊢ Nat",
++   "goals": "t : Nat ⊢ Nat",
+    "endPos": {"line": 1, "column": 39}}],
+  "env": 0}
+ 
+diff --git a/test/calc.expected.out b/test/calc.expected.out
+index 94f6a9f..fde8fee 100644
+--- a/test/calc.expected.out
++++ b/test/calc.expected.out
+@@ -1,35 +1,22 @@
+ {"tactics":
+  [{"usedConstants":
+-   ["Trans.trans",
+-    "sorryAx",
+-    "instOfNatNat",
+-    "instTransEq",
+-    "Nat",
+-    "OfNat.ofNat",
+-    "Bool.false",
+-    "Eq"],
++   ["Trans.trans", "instOfNatNat", "instTransEq", "Nat", "OfNat.ofNat", "Eq"],
+    "tactic": "calc\n  3 = 4 := by sorry\n  4 = 5 := by sorry",
+    "proofState": 2,
+    "pos": {"line": 1, "column": 22},
+    "goals": "⊢ 3 = 5",
+    "endPos": {"line": 3, "column": 19}},
+-  {"usedConstants": [],
+-   "tactic": "\n  3 = 4 := by sorry\n  4 = 5 := by sorry",
+-   "proofState": 3,
+-   "pos": {"line": 2, "column": 2},
+-   "goals": "no goals",
+-   "endPos": {"line": 3, "column": 19}},
+   {"usedConstants":
+    ["sorryAx", "instOfNatNat", "Nat", "OfNat.ofNat", "Bool.false", "Eq"],
+    "tactic": "sorry",
+-   "proofState": 4,
++   "proofState": 3,
+    "pos": {"line": 2, "column": 14},
+    "goals": "⊢ 3 = 4",
+    "endPos": {"line": 2, "column": 19}},
+   {"usedConstants":
+    ["sorryAx", "instOfNatNat", "Nat", "OfNat.ofNat", "Bool.false", "Eq"],
+    "tactic": "sorry",
+-   "proofState": 5,
++   "proofState": 4,
+    "pos": {"line": 3, "column": 14},
+    "goals": "⊢ 4 = 5",
+    "endPos": {"line": 3, "column": 19}}],
+diff --git a/test/name_generator.expected.out b/test/name_generator.expected.out
+index b4d885b..557d03b 100644
+--- a/test/name_generator.expected.out
++++ b/test/name_generator.expected.out
+@@ -24,13 +24,13 @@
+  "goals": []}
+ 
+ {"traces":
+- ["[Meta.Tactic.simp.rewrite] gt_iff_lt:1000, x > 0 ==> 0 < x",
++ ["[Meta.Tactic.simp.rewrite] @gt_iff_lt:1000, x > 0 ==> 0 < x",
+   "[Meta.Tactic.simp.rewrite] h0:1000, 0 < x ==> True"],
+  "proofState": 6,
+  "goals": []}
+ 
+ {"traces":
+- ["[Meta.Tactic.simp.rewrite] gt_iff_lt:1000, x > 0 ==> 0 < x",
++ ["[Meta.Tactic.simp.rewrite] @gt_iff_lt:1000, x > 0 ==> 0 < x",
+   "[Meta.Tactic.simp.rewrite] h0:1000, 0 < x ==> True"],
+  "proofState": 7,
+  "goals": []}
+diff --git a/test/no_goal_sorry.expected.out b/test/no_goal_sorry.expected.out
+index 5c89f5a..5be11b7 100644
+--- a/test/no_goal_sorry.expected.out
++++ b/test/no_goal_sorry.expected.out
+@@ -4,8 +4,8 @@
+    "endPos": {"line": 2, "column": 18},
+    "data": "type expected, got\n  (set Nat : ?m.8 PUnit)"},
+   {"severity": "error",
+-   "pos": {"line": 2, "column": 22},
+-   "endPos": {"line": 2, "column": 24},
+-   "data": "Case tag 'body' not found.\n\nThere are no cases to select."}],
++   "pos": {"line": 3, "column": 2},
++   "endPos": {"line": 3, "column": 7},
++   "data": "no goals to be solved"}],
+  "env": 0}
+ 
+diff --git a/test/trace_simp.expected.out b/test/trace_simp.expected.out
+index 2a85844..1f6fbeb 100644
+--- a/test/trace_simp.expected.out
++++ b/test/trace_simp.expected.out
+@@ -9,7 +9,7 @@
+    "pos": {"line": 1, "column": 23},
+    "endPos": {"line": 1, "column": 27},
+    "data":
+-   "[Meta.Tactic.simp.rewrite] f_def:1000, f ==> 37\n[Meta.Tactic.simp.rewrite] eq_self:1000, 37 = 37 ==> True"}],
++   "[Meta.Tactic.simp.rewrite] f_def:1000, f ==> 37\n[Meta.Tactic.simp.rewrite] @eq_self:1000, 37 = 37 ==> True"}],
+  "env": 3}
+ 
+ {"sorries":
+@@ -28,7 +28,7 @@
+ 
+ {"traces":
+  ["[Meta.Tactic.simp.rewrite] f_def:1000, f ==> 37",
+-  "[Meta.Tactic.simp.rewrite] eq_self:1000, 37 = 37 ==> True"],
++  "[Meta.Tactic.simp.rewrite] @eq_self:1000, 37 = 37 ==> True"],
+  "proofState": 2,
+  "goals": []}
+ 

--- a/versions/v4.9.0-rc1.diff
+++ b/versions/v4.9.0-rc1.diff
@@ -1,0 +1,438 @@
+diff --git a/REPL/Frontend.lean b/REPL/Frontend.lean
+index 9cc0914..a2bb150 100644
+--- a/REPL/Frontend.lean
++++ b/REPL/Frontend.lean
+@@ -20,7 +20,10 @@ def processCommandsWithInfoTrees
+     (commandState : Command.State) : IO (Command.State × List Message × List InfoTree) := do
+   let commandState := { commandState with infoState.enabled := true }
+   let s ← IO.processCommands inputCtx parserState commandState <&> Frontend.State.commandState
+-  pure (s, s.messages.toList, s.infoState.trees.toList)
++  let msgs := s.messages.toList.drop commandState.messages.toList.length
++  let trees := s.infoState.trees.toList.drop commandState.infoState.trees.size
++
++  pure (s, msgs, trees)
+ 
+ /--
+ Process some text input, with or without an existing command state.
+diff --git a/REPL/JSON.lean b/REPL/JSON.lean
+index d5c5ba2..b63c5ea 100644
+--- a/REPL/JSON.lean
++++ b/REPL/JSON.lean
+@@ -83,7 +83,7 @@ structure Sorry where
+ deriving FromJson
+ 
+ instance : ToJson Sorry where
+-  toJson r := Json.mkObj <| .flatten [
++  toJson r := Json.mkObj <| .join [
+     [("goal", r.goal)],
+     [("proofState", toJson r.proofState)],
+     if r.pos.line ≠ 0 then [("pos", toJson r.pos)] else [],
+@@ -132,7 +132,7 @@ def Json.nonemptyList [ToJson α] (k : String) : List α → List (String × Jso
+   | l  => [⟨k, toJson l⟩]
+ 
+ instance : ToJson CommandResponse where
+-  toJson r := Json.mkObj <| .flatten [
++  toJson r := Json.mkObj <| .join [
+     [("env", r.env)],
+     Json.nonemptyList "messages" r.messages,
+     Json.nonemptyList "sorries" r.sorries,
+@@ -153,7 +153,7 @@ structure ProofStepResponse where
+ deriving ToJson, FromJson
+ 
+ instance : ToJson ProofStepResponse where
+-  toJson r := Json.mkObj <| .flatten [
++  toJson r := Json.mkObj <| .join [
+     [("proofState", r.proofState)],
+     [("goals", toJson r.goals)],
+     Json.nonemptyList "messages" r.messages,
+diff --git a/REPL/Lean/Environment.lean b/REPL/Lean/Environment.lean
+index 0b4be3c..61d4e76 100644
+--- a/REPL/Lean/Environment.lean
++++ b/REPL/Lean/Environment.lean
+@@ -26,6 +26,6 @@ and then replace the new constants.
+ def unpickle (path : FilePath) : IO (Environment × CompactedRegion) := unsafe do
+   let ((imports, map₂), region) ← _root_.unpickle (Array Import × PHashMap Name ConstantInfo) path
+   let env ← importModules imports {} 0
+-  return (← env.replay (Std.HashMap.ofList map₂.toList), region)
++  return (← env.replay (HashMap.ofList map₂.toList), region)
+ 
+ end Lean.Environment
+diff --git a/REPL/Lean/InfoTree.lean b/REPL/Lean/InfoTree.lean
+index 7abf0b8..d3b28c1 100644
+--- a/REPL/Lean/InfoTree.lean
++++ b/REPL/Lean/InfoTree.lean
+@@ -131,9 +131,9 @@ partial def filter (p : Info → Bool) (m : MVarId → Bool := fun _ => false) :
+   | .context ctx tree => tree.filter p m |>.map (.context ctx)
+   | .node info children =>
+     if p info then
+-      [.node info (children.toList.map (filter p m)).flatten.toPArray']
++      [.node info (children.toList.map (filter p m)).join.toPArray']
+     else
+-      (children.toList.map (filter p m)).flatten
++      (children.toList.map (filter p m)).join
+   | .hole mvar => if m mvar then [.hole mvar] else []
+ 
+ /-- Discard all nodes besides `.context` nodes and `TacticInfo` nodes. -/
+@@ -156,7 +156,7 @@ partial def findAllInfo (t : InfoTree) (ctx? : Option ContextInfo) (p : Info →
+   | context ctx t => t.findAllInfo (ctx.mergeIntoOuter? ctx?) p
+   | node i ts  =>
+     let info := if p i then [(i, ctx?)] else []
+-    let rest := ts.toList.flatMap (fun t => t.findAllInfo ctx? p)
++    let rest := ts.toList.bind (fun t => t.findAllInfo ctx? p)
+     info ++ rest
+   | _ => []
+ 
+@@ -214,13 +214,13 @@ def sorries (t : InfoTree) : List (ContextInfo × SorryType × Position × Posit
+ 
+ def tactics (t : InfoTree) : List (ContextInfo × Syntax × List MVarId × Position × Position × Array Name) :=
+     -- HACK: creating a child ngen
+-  t.findTacticNodes.map fun ⟨i, ctx⟩ => 
+-    let range := stxRange ctx.fileMap i.stx 
+-    ( { ctx with mctx := i.mctxBefore, ngen := ctx.ngen.mkChild.1 }, 
+-      i.stx, 
+-      i.goalsBefore, 
+-      range.fst, 
+-      range.snd, 
++  t.findTacticNodes.map fun ⟨i, ctx⟩ =>
++    let range := stxRange ctx.fileMap i.stx
++    ( { ctx with mctx := i.mctxBefore, ngen := ctx.ngen.mkChild.1 },
++      i.stx,
++      i.goalsBefore,
++      range.fst,
++      range.snd,
+       i.getUsedConstantsAsSet.toArray )
+ 
+ 
+diff --git a/REPL/Main.lean b/REPL/Main.lean
+index a4b97c3..8211b8c 100644
+--- a/REPL/Main.lean
++++ b/REPL/Main.lean
+@@ -95,7 +95,7 @@ def recordProofSnapshot (proofState : ProofSnapshot) : M m Nat := do
+   return id
+ 
+ def sorries (trees : List InfoTree) (env? : Option Environment) : M m (List Sorry) :=
+-  trees.flatMap InfoTree.sorries |>.filter (fun t => match t.2.1 with
++  trees.bind InfoTree.sorries |>.filter (fun t => match t.2.1 with
+     | .term _ none => false
+     | _ => true ) |>.mapM
+       fun ⟨ctx, g, pos, endPos⟩ => do
+@@ -117,7 +117,7 @@ def ppTactic (ctx : ContextInfo) (stx : Syntax) : IO Format :=
+     pure "<failed to pretty print>"
+ 
+ def tactics (trees : List InfoTree) : M m (List Tactic) :=
+-  trees.flatMap InfoTree.tactics |>.mapM
++  trees.bind InfoTree.tactics |>.mapM
+     fun ⟨ctx, stx, goals, pos, endPos, ns⟩ => do
+       let proofState := some (← ProofSnapshot.create ctx none none goals)
+       let goals := s!"{(← ctx.ppGoals goals)}".trim
+@@ -218,9 +218,9 @@ def runCommand (s : Command) : M IO (CommandResponse ⊕ Error) := do
+   let env ← recordCommandSnapshot cmdSnapshot
+   let jsonTrees := match s.infotree with
+   | some "full" => trees
+-  | some "tactics" => trees.flatMap InfoTree.retainTacticInfo
+-  | some "original" => trees.flatMap InfoTree.retainTacticInfo |>.flatMap InfoTree.retainOriginal
+-  | some "substantive" => trees.flatMap InfoTree.retainTacticInfo |>.flatMap InfoTree.retainSubstantive
++  | some "tactics" => trees.bind InfoTree.retainTacticInfo
++  | some "original" => trees.bind InfoTree.retainTacticInfo |>.bind InfoTree.retainOriginal
++  | some "substantive" => trees.bind InfoTree.retainTacticInfo |>.bind InfoTree.retainSubstantive
+   | _ => []
+   let infotree ← if jsonTrees.isEmpty then
+     pure none
+diff --git a/REPL/Snapshots.lean b/REPL/Snapshots.lean
+index 1114c24..7462141 100644
+--- a/REPL/Snapshots.lean
++++ b/REPL/Snapshots.lean
+@@ -83,7 +83,7 @@ def unpickle (path : FilePath) : IO (CommandSnapshot × CompactedRegion) := unsa
+   let ((imports, map₂, cmdState, cmdContext), region) ←
+     _root_.unpickle (Array Import × PHashMap Name ConstantInfo × CompactableCommandSnapshot ×
+       Command.Context) path
+-  let env ← (← importModules imports {} 0).replay (Std.HashMap.ofList map₂.toList)
++  let env ← (← importModules imports {} 0).replay (HashMap.ofList map₂.toList)
+   let p' : CommandSnapshot :=
+   { cmdState := { cmdState with env }
+     cmdContext }
+@@ -284,9 +284,9 @@ def unpickle (path : FilePath) (cmd? : Option CommandSnapshot) :
+   let env ← match cmd? with
+   | none =>
+     enableInitializersExecution
+-    (← importModules imports {} 0).replay (Std.HashMap.ofList map₂.toList)
++    (← importModules imports {} 0).replay (HashMap.ofList map₂.toList)
+   | some cmd =>
+-    cmd.cmdState.env.replay (Std.HashMap.ofList map₂.toList)
++    cmd.cmdState.env.replay (HashMap.ofList map₂.toList)
+   let p' : ProofSnapshot :=
+   { coreState := { coreState with env }
+     coreContext
+diff --git a/lakefile.lean b/lakefile.lean
+new file mode 100644
+index 0000000..33dd0da
+--- /dev/null
++++ b/lakefile.lean
+@@ -0,0 +1,15 @@
++import Lake
++open Lake DSL
++
++package REPL {
++  -- add package configuration options here
++}
++
++lean_lib REPL {
++  -- add library configuration options here
++}
++
++@[default_target]
++lean_exe repl where
++  root := `REPL.Main
++  supportInterpreter := true
+diff --git a/lakefile.toml b/lakefile.toml
+deleted file mode 100644
+index 589e047..0000000
+--- a/lakefile.toml
++++ /dev/null
+@@ -1,10 +0,0 @@
+-name = "REPL"
+-defaultTargets = ["repl"]
+-
+-[[lean_lib]]
+-name = "REPL"
+-
+-[[lean_exe]]
+-name = "repl"
+-root = "REPL.Main"
+-supportInterpreter = true
+diff --git a/lean-toolchain b/lean-toolchain
+index 1e70935..0ba3faf 100644
+--- a/lean-toolchain
++++ b/lean-toolchain
+@@ -1 +1 @@
+-leanprover/lean4:v4.14.0
++leanprover/lean4:v4.9.0-rc1
+diff --git a/test/Mathlib/lake-manifest.json b/test/Mathlib/lake-manifest.json
+index f312e5a..c29f05b 100644
+--- a/test/Mathlib/lake-manifest.json
++++ b/test/Mathlib/lake-manifest.json
+@@ -1,95 +1,68 @@
+-{"version": "1.1.0",
++{"version": "1.0.0",
+  "packagesDir": ".lake/packages",
+  "packages":
+- [{"url": "https://github.com/leanprover-community/mathlib4",
++ [{"url": "https://github.com/leanprover-community/batteries",
+    "type": "git",
+    "subDir": null,
+-   "scope": "",
+-   "rev": "4bbdccd9c5f862bf90ff12f0a9e2c8be032b9a84",
+-   "name": "mathlib",
+-   "manifestFile": "lake-manifest.json",
+-   "inputRev": "v4.14.0",
+-   "inherited": false,
+-   "configFile": "lakefile.lean"},
+-  {"url": "https://github.com/leanprover-community/plausible",
+-   "type": "git",
+-   "subDir": null,
+-   "scope": "leanprover-community",
+-   "rev": "42dc02bdbc5d0c2f395718462a76c3d87318f7fa",
+-   "name": "plausible",
++   "rev": "af2dda22771c59db026c48ac0aabc73b72b7a4de",
++   "name": "batteries",
+    "manifestFile": "lake-manifest.json",
+-   "inputRev": "main",
++   "inputRev": "nightly-testing",
+    "inherited": true,
+-   "configFile": "lakefile.toml"},
+-  {"url": "https://github.com/leanprover-community/LeanSearchClient",
++   "configFile": "lakefile.lean"},
++  {"url": "https://github.com/leanprover-community/quote4",
+    "type": "git",
+    "subDir": null,
+-   "scope": "leanprover-community",
+-   "rev": "d7caecce0d0f003fd5e9cce9a61f1dd6ba83142b",
+-   "name": "LeanSearchClient",
++   "rev": "44f57616b0d9b8f9e5606f2c58d01df54840eba7",
++   "name": "Qq",
+    "manifestFile": "lake-manifest.json",
+-   "inputRev": "main",
++   "inputRev": "nightly-testing",
+    "inherited": true,
+-   "configFile": "lakefile.toml"},
+-  {"url": "https://github.com/leanprover-community/import-graph",
++   "configFile": "lakefile.lean"},
++  {"url": "https://github.com/leanprover-community/aesop",
+    "type": "git",
+    "subDir": null,
+-   "scope": "leanprover-community",
+-   "rev": "519e509a28864af5bed98033dd33b95cf08e9aa7",
+-   "name": "importGraph",
++   "rev": "f744aab6fc4e06553464e6ae66730a3b14b8e615",
++   "name": "aesop",
+    "manifestFile": "lake-manifest.json",
+-   "inputRev": "v4.14.0",
++   "inputRev": "nightly-testing",
+    "inherited": true,
+    "configFile": "lakefile.toml"},
+   {"url": "https://github.com/leanprover-community/ProofWidgets4",
+    "type": "git",
+    "subDir": null,
+-   "scope": "leanprover-community",
+-   "rev": "68280daef58803f68368eb2e53046dabcd270c9d",
++   "rev": "e6b6247c61280c77ade6bbf0bc3c66a44fe2e0c5",
+    "name": "proofwidgets",
+    "manifestFile": "lake-manifest.json",
+-   "inputRev": "v0.0.47",
++   "inputRev": "v0.0.36",
+    "inherited": true,
+    "configFile": "lakefile.lean"},
+-  {"url": "https://github.com/leanprover-community/aesop",
+-   "type": "git",
+-   "subDir": null,
+-   "scope": "leanprover-community",
+-   "rev": "5a0ec8588855265ade536f35bcdcf0fb24fd6030",
+-   "name": "aesop",
+-   "manifestFile": "lake-manifest.json",
+-   "inputRev": "v4.14.0",
+-   "inherited": true,
+-   "configFile": "lakefile.toml"},
+-  {"url": "https://github.com/leanprover-community/quote4",
++  {"url": "https://github.com/leanprover/lean4-cli",
+    "type": "git",
+    "subDir": null,
+-   "scope": "leanprover-community",
+-   "rev": "303b23fbcea94ac4f96e590c1cad6618fd4f5f41",
+-   "name": "Qq",
++   "rev": "a11566029bd9ec4f68a65394e8c3ff1af74c1a29",
++   "name": "Cli",
+    "manifestFile": "lake-manifest.json",
+-   "inputRev": "master",
++   "inputRev": "main",
+    "inherited": true,
+    "configFile": "lakefile.lean"},
+-  {"url": "https://github.com/leanprover-community/batteries",
++  {"url": "https://github.com/leanprover-community/import-graph.git",
+    "type": "git",
+    "subDir": null,
+-   "scope": "leanprover-community",
+-   "rev": "8d6c853f11a5172efa0e96b9f2be1a83d861cdd9",
+-   "name": "batteries",
++   "rev": "7983e959f8f4a79313215720de3ef1eca2d6d474",
++   "name": "importGraph",
+    "manifestFile": "lake-manifest.json",
+-   "inputRev": "v4.14.0",
++   "inputRev": "main",
+    "inherited": true,
+    "configFile": "lakefile.toml"},
+-  {"url": "https://github.com/leanprover/lean4-cli",
++  {"url": "https://github.com/leanprover-community/mathlib4",
+    "type": "git",
+    "subDir": null,
+-   "scope": "leanprover",
+-   "rev": "726b3c9ad13acca724d4651f14afc4804a7b0e4d",
+-   "name": "Cli",
++   "rev": "bbf0d1e39b5faac9276413942ac15bd64de65c1e",
++   "name": "mathlib",
+    "manifestFile": "lake-manifest.json",
+-   "inputRev": "main",
+-   "inherited": true,
+-   "configFile": "lakefile.toml"}],
++   "inputRev": "master",
++   "inherited": false,
++   "configFile": "lakefile.lean"}],
+  "name": "«repl-mathlib-tests»",
+  "lakeDir": ".lake"}
+diff --git a/test/Mathlib/lakefile.lean b/test/Mathlib/lakefile.lean
+new file mode 100644
+index 0000000..3257376
+--- /dev/null
++++ b/test/Mathlib/lakefile.lean
+@@ -0,0 +1,11 @@
++import Lake
++open Lake DSL
++
++package «repl-mathlib-tests» where
++  -- add package configuration options here
++  require mathlib from git "https://github.com/leanprover-community/mathlib4" @ "master"
++
++@[default_target]
++lean_lib «ReplMathlibTests» where
++  globs := #[.submodules `test]
++  -- add library configuration options here
+diff --git a/test/Mathlib/lakefile.toml b/test/Mathlib/lakefile.toml
+deleted file mode 100644
+index 6ff9631..0000000
+--- a/test/Mathlib/lakefile.toml
++++ /dev/null
+@@ -1,11 +0,0 @@
+-name = "«repl-mathlib-tests»"
+-defaultTargets = ["ReplMathlibTests"]
+-
+-[[require]]
+-name = "mathlib"
+-git = "https://github.com/leanprover-community/mathlib4"
+-rev = "v4.14.0"
+-
+-[[lean_lib]]
+-name = "ReplMathlibTests"
+-globs = ["test.+"]
+diff --git a/test/Mathlib/lean-toolchain b/test/Mathlib/lean-toolchain
+index 401bc14..0ba3faf 100644
+--- a/test/Mathlib/lean-toolchain
++++ b/test/Mathlib/lean-toolchain
+@@ -1 +1 @@
+-leanprover/lean4:v4.14.0
+\ No newline at end of file
++leanprover/lean4:v4.9.0-rc1
+diff --git a/test/all_tactics.expected.out b/test/all_tactics.expected.out
+index 6ec808c..5374db8 100644
+--- a/test/all_tactics.expected.out
++++ b/test/all_tactics.expected.out
+@@ -9,7 +9,7 @@
+    "tactic": "exact t",
+    "proofState": 1,
+    "pos": {"line": 1, "column": 32},
+-   "goals": "t : Nat\n⊢ Nat",
++   "goals": "t : Nat ⊢ Nat",
+    "endPos": {"line": 1, "column": 39}}],
+  "env": 0}
+ 
+diff --git a/test/calc.expected.out b/test/calc.expected.out
+index 94f6a9f..fde8fee 100644
+--- a/test/calc.expected.out
++++ b/test/calc.expected.out
+@@ -1,35 +1,22 @@
+ {"tactics":
+  [{"usedConstants":
+-   ["Trans.trans",
+-    "sorryAx",
+-    "instOfNatNat",
+-    "instTransEq",
+-    "Nat",
+-    "OfNat.ofNat",
+-    "Bool.false",
+-    "Eq"],
++   ["Trans.trans", "instOfNatNat", "instTransEq", "Nat", "OfNat.ofNat", "Eq"],
+    "tactic": "calc\n  3 = 4 := by sorry\n  4 = 5 := by sorry",
+    "proofState": 2,
+    "pos": {"line": 1, "column": 22},
+    "goals": "⊢ 3 = 5",
+    "endPos": {"line": 3, "column": 19}},
+-  {"usedConstants": [],
+-   "tactic": "\n  3 = 4 := by sorry\n  4 = 5 := by sorry",
+-   "proofState": 3,
+-   "pos": {"line": 2, "column": 2},
+-   "goals": "no goals",
+-   "endPos": {"line": 3, "column": 19}},
+   {"usedConstants":
+    ["sorryAx", "instOfNatNat", "Nat", "OfNat.ofNat", "Bool.false", "Eq"],
+    "tactic": "sorry",
+-   "proofState": 4,
++   "proofState": 3,
+    "pos": {"line": 2, "column": 14},
+    "goals": "⊢ 3 = 4",
+    "endPos": {"line": 2, "column": 19}},
+   {"usedConstants":
+    ["sorryAx", "instOfNatNat", "Nat", "OfNat.ofNat", "Bool.false", "Eq"],
+    "tactic": "sorry",
+-   "proofState": 5,
++   "proofState": 4,
+    "pos": {"line": 3, "column": 14},
+    "goals": "⊢ 4 = 5",
+    "endPos": {"line": 3, "column": 19}}],

--- a/versions/v4.9.0-rc1.diff
+++ b/versions/v4.9.0-rc1.diff
@@ -163,43 +163,6 @@ index 1114c24..7462141 100644
    let p' : ProofSnapshot :=
    { coreState := { coreState with env }
      coreContext
-diff --git a/lakefile.lean b/lakefile.lean
-new file mode 100644
-index 0000000..33dd0da
---- /dev/null
-+++ b/lakefile.lean
-@@ -0,0 +1,15 @@
-+import Lake
-+open Lake DSL
-+
-+package REPL {
-+  -- add package configuration options here
-+}
-+
-+lean_lib REPL {
-+  -- add library configuration options here
-+}
-+
-+@[default_target]
-+lean_exe repl where
-+  root := `REPL.Main
-+  supportInterpreter := true
-diff --git a/lakefile.toml b/lakefile.toml
-deleted file mode 100644
-index 589e047..0000000
---- a/lakefile.toml
-+++ /dev/null
-@@ -1,10 +0,0 @@
--name = "REPL"
--defaultTargets = ["repl"]
--
--[[lean_lib]]
--name = "REPL"
--
--[[lean_exe]]
--name = "repl"
--root = "REPL.Main"
--supportInterpreter = true
 diff --git a/lean-toolchain b/lean-toolchain
 index 1e70935..0ba3faf 100644
 --- a/lean-toolchain
@@ -207,171 +170,33 @@ index 1e70935..0ba3faf 100644
 @@ -1 +1 @@
 -leanprover/lean4:v4.14.0
 +leanprover/lean4:v4.9.0-rc1
-diff --git a/test/Mathlib/lake-manifest.json b/test/Mathlib/lake-manifest.json
-index f312e5a..c29f05b 100644
---- a/test/Mathlib/lake-manifest.json
-+++ b/test/Mathlib/lake-manifest.json
-@@ -1,95 +1,68 @@
--{"version": "1.1.0",
-+{"version": "1.0.0",
-  "packagesDir": ".lake/packages",
-  "packages":
-- [{"url": "https://github.com/leanprover-community/mathlib4",
-+ [{"url": "https://github.com/leanprover-community/batteries",
-    "type": "git",
-    "subDir": null,
--   "scope": "",
--   "rev": "4bbdccd9c5f862bf90ff12f0a9e2c8be032b9a84",
--   "name": "mathlib",
--   "manifestFile": "lake-manifest.json",
--   "inputRev": "v4.14.0",
--   "inherited": false,
--   "configFile": "lakefile.lean"},
--  {"url": "https://github.com/leanprover-community/plausible",
--   "type": "git",
--   "subDir": null,
--   "scope": "leanprover-community",
--   "rev": "42dc02bdbc5d0c2f395718462a76c3d87318f7fa",
--   "name": "plausible",
-+   "rev": "af2dda22771c59db026c48ac0aabc73b72b7a4de",
-+   "name": "batteries",
-    "manifestFile": "lake-manifest.json",
--   "inputRev": "main",
-+   "inputRev": "nightly-testing",
-    "inherited": true,
--   "configFile": "lakefile.toml"},
--  {"url": "https://github.com/leanprover-community/LeanSearchClient",
-+   "configFile": "lakefile.lean"},
-+  {"url": "https://github.com/leanprover-community/quote4",
-    "type": "git",
-    "subDir": null,
--   "scope": "leanprover-community",
--   "rev": "d7caecce0d0f003fd5e9cce9a61f1dd6ba83142b",
--   "name": "LeanSearchClient",
-+   "rev": "44f57616b0d9b8f9e5606f2c58d01df54840eba7",
-+   "name": "Qq",
-    "manifestFile": "lake-manifest.json",
--   "inputRev": "main",
-+   "inputRev": "nightly-testing",
-    "inherited": true,
--   "configFile": "lakefile.toml"},
--  {"url": "https://github.com/leanprover-community/import-graph",
-+   "configFile": "lakefile.lean"},
-+  {"url": "https://github.com/leanprover-community/aesop",
-    "type": "git",
-    "subDir": null,
--   "scope": "leanprover-community",
--   "rev": "519e509a28864af5bed98033dd33b95cf08e9aa7",
--   "name": "importGraph",
-+   "rev": "f744aab6fc4e06553464e6ae66730a3b14b8e615",
-+   "name": "aesop",
-    "manifestFile": "lake-manifest.json",
--   "inputRev": "v4.14.0",
-+   "inputRev": "nightly-testing",
-    "inherited": true,
-    "configFile": "lakefile.toml"},
-   {"url": "https://github.com/leanprover-community/ProofWidgets4",
-    "type": "git",
-    "subDir": null,
--   "scope": "leanprover-community",
--   "rev": "68280daef58803f68368eb2e53046dabcd270c9d",
-+   "rev": "e6b6247c61280c77ade6bbf0bc3c66a44fe2e0c5",
-    "name": "proofwidgets",
-    "manifestFile": "lake-manifest.json",
--   "inputRev": "v0.0.47",
-+   "inputRev": "v0.0.36",
-    "inherited": true,
-    "configFile": "lakefile.lean"},
--  {"url": "https://github.com/leanprover-community/aesop",
--   "type": "git",
--   "subDir": null,
--   "scope": "leanprover-community",
--   "rev": "5a0ec8588855265ade536f35bcdcf0fb24fd6030",
--   "name": "aesop",
--   "manifestFile": "lake-manifest.json",
--   "inputRev": "v4.14.0",
--   "inherited": true,
--   "configFile": "lakefile.toml"},
--  {"url": "https://github.com/leanprover-community/quote4",
-+  {"url": "https://github.com/leanprover/lean4-cli",
-    "type": "git",
-    "subDir": null,
--   "scope": "leanprover-community",
--   "rev": "303b23fbcea94ac4f96e590c1cad6618fd4f5f41",
--   "name": "Qq",
-+   "rev": "a11566029bd9ec4f68a65394e8c3ff1af74c1a29",
-+   "name": "Cli",
-    "manifestFile": "lake-manifest.json",
--   "inputRev": "master",
-+   "inputRev": "main",
-    "inherited": true,
-    "configFile": "lakefile.lean"},
--  {"url": "https://github.com/leanprover-community/batteries",
-+  {"url": "https://github.com/leanprover-community/import-graph.git",
-    "type": "git",
-    "subDir": null,
--   "scope": "leanprover-community",
--   "rev": "8d6c853f11a5172efa0e96b9f2be1a83d861cdd9",
--   "name": "batteries",
-+   "rev": "7983e959f8f4a79313215720de3ef1eca2d6d474",
-+   "name": "importGraph",
-    "manifestFile": "lake-manifest.json",
--   "inputRev": "v4.14.0",
-+   "inputRev": "main",
-    "inherited": true,
-    "configFile": "lakefile.toml"},
--  {"url": "https://github.com/leanprover/lean4-cli",
-+  {"url": "https://github.com/leanprover-community/mathlib4",
-    "type": "git",
-    "subDir": null,
--   "scope": "leanprover",
--   "rev": "726b3c9ad13acca724d4651f14afc4804a7b0e4d",
--   "name": "Cli",
-+   "rev": "bbf0d1e39b5faac9276413942ac15bd64de65c1e",
-+   "name": "mathlib",
-    "manifestFile": "lake-manifest.json",
--   "inputRev": "main",
--   "inherited": true,
--   "configFile": "lakefile.toml"}],
-+   "inputRev": "master",
-+   "inherited": false,
-+   "configFile": "lakefile.lean"}],
-  "name": "«repl-mathlib-tests»",
-  "lakeDir": ".lake"}
-diff --git a/test/Mathlib/lakefile.lean b/test/Mathlib/lakefile.lean
-new file mode 100644
-index 0000000..3257376
---- /dev/null
-+++ b/test/Mathlib/lakefile.lean
-@@ -0,0 +1,11 @@
-+import Lake
-+open Lake DSL
-+
-+package «repl-mathlib-tests» where
-+  -- add package configuration options here
-+  require mathlib from git "https://github.com/leanprover-community/mathlib4" @ "master"
-+
-+@[default_target]
-+lean_lib «ReplMathlibTests» where
-+  globs := #[.submodules `test]
-+  -- add library configuration options here
+diff --git a/test.sh b/test.sh
+index 070ce3d..6b6a38c 100755
+--- a/test.sh
++++ b/test.sh
+@@ -41,6 +41,6 @@ for infile in $IN_DIR/*.in; do
+ 
+ done
+ 
+-# Run the Mathlib tests
+-cp lean-toolchain test/Mathlib/
+-cd test/Mathlib/ && ./test.sh
++# Run the Mathlib tests - skipped as it seems Mathlib v4.9.0-rc1 is buggy
++# cp lean-toolchain test/Mathlib/
++# cd test/Mathlib/ && ./test.sh
 diff --git a/test/Mathlib/lakefile.toml b/test/Mathlib/lakefile.toml
-deleted file mode 100644
-index 6ff9631..0000000
+index 6ff9631..8732a10 100644
 --- a/test/Mathlib/lakefile.toml
-+++ /dev/null
-@@ -1,11 +0,0 @@
--name = "«repl-mathlib-tests»"
--defaultTargets = ["ReplMathlibTests"]
--
--[[require]]
--name = "mathlib"
--git = "https://github.com/leanprover-community/mathlib4"
++++ b/test/Mathlib/lakefile.toml
+@@ -4,7 +4,7 @@ defaultTargets = ["ReplMathlibTests"]
+ [[require]]
+ name = "mathlib"
+ git = "https://github.com/leanprover-community/mathlib4"
 -rev = "v4.14.0"
--
--[[lean_lib]]
--name = "ReplMathlibTests"
--globs = ["test.+"]
++rev = "v4.9.0-rc1"
+ 
+ [[lean_lib]]
+ name = "ReplMathlibTests"
 diff --git a/test/Mathlib/lean-toolchain b/test/Mathlib/lean-toolchain
 index 401bc14..0ba3faf 100644
 --- a/test/Mathlib/lean-toolchain

--- a/versions/v4.9.0-rc2.diff
+++ b/versions/v4.9.0-rc2.diff
@@ -1,0 +1,379 @@
+diff --git a/REPL/Frontend.lean b/REPL/Frontend.lean
+index 9cc0914..a2bb150 100644
+--- a/REPL/Frontend.lean
++++ b/REPL/Frontend.lean
+@@ -20,7 +20,10 @@ def processCommandsWithInfoTrees
+     (commandState : Command.State) : IO (Command.State × List Message × List InfoTree) := do
+   let commandState := { commandState with infoState.enabled := true }
+   let s ← IO.processCommands inputCtx parserState commandState <&> Frontend.State.commandState
+-  pure (s, s.messages.toList, s.infoState.trees.toList)
++  let msgs := s.messages.toList.drop commandState.messages.toList.length
++  let trees := s.infoState.trees.toList.drop commandState.infoState.trees.size
++
++  pure (s, msgs, trees)
+ 
+ /--
+ Process some text input, with or without an existing command state.
+diff --git a/REPL/JSON.lean b/REPL/JSON.lean
+index d5c5ba2..b63c5ea 100644
+--- a/REPL/JSON.lean
++++ b/REPL/JSON.lean
+@@ -83,7 +83,7 @@ structure Sorry where
+ deriving FromJson
+ 
+ instance : ToJson Sorry where
+-  toJson r := Json.mkObj <| .flatten [
++  toJson r := Json.mkObj <| .join [
+     [("goal", r.goal)],
+     [("proofState", toJson r.proofState)],
+     if r.pos.line ≠ 0 then [("pos", toJson r.pos)] else [],
+@@ -132,7 +132,7 @@ def Json.nonemptyList [ToJson α] (k : String) : List α → List (String × Jso
+   | l  => [⟨k, toJson l⟩]
+ 
+ instance : ToJson CommandResponse where
+-  toJson r := Json.mkObj <| .flatten [
++  toJson r := Json.mkObj <| .join [
+     [("env", r.env)],
+     Json.nonemptyList "messages" r.messages,
+     Json.nonemptyList "sorries" r.sorries,
+@@ -153,7 +153,7 @@ structure ProofStepResponse where
+ deriving ToJson, FromJson
+ 
+ instance : ToJson ProofStepResponse where
+-  toJson r := Json.mkObj <| .flatten [
++  toJson r := Json.mkObj <| .join [
+     [("proofState", r.proofState)],
+     [("goals", toJson r.goals)],
+     Json.nonemptyList "messages" r.messages,
+diff --git a/REPL/Lean/Environment.lean b/REPL/Lean/Environment.lean
+index 0b4be3c..61d4e76 100644
+--- a/REPL/Lean/Environment.lean
++++ b/REPL/Lean/Environment.lean
+@@ -26,6 +26,6 @@ and then replace the new constants.
+ def unpickle (path : FilePath) : IO (Environment × CompactedRegion) := unsafe do
+   let ((imports, map₂), region) ← _root_.unpickle (Array Import × PHashMap Name ConstantInfo) path
+   let env ← importModules imports {} 0
+-  return (← env.replay (Std.HashMap.ofList map₂.toList), region)
++  return (← env.replay (HashMap.ofList map₂.toList), region)
+ 
+ end Lean.Environment
+diff --git a/REPL/Lean/InfoTree.lean b/REPL/Lean/InfoTree.lean
+index 7abf0b8..d3b28c1 100644
+--- a/REPL/Lean/InfoTree.lean
++++ b/REPL/Lean/InfoTree.lean
+@@ -131,9 +131,9 @@ partial def filter (p : Info → Bool) (m : MVarId → Bool := fun _ => false) :
+   | .context ctx tree => tree.filter p m |>.map (.context ctx)
+   | .node info children =>
+     if p info then
+-      [.node info (children.toList.map (filter p m)).flatten.toPArray']
++      [.node info (children.toList.map (filter p m)).join.toPArray']
+     else
+-      (children.toList.map (filter p m)).flatten
++      (children.toList.map (filter p m)).join
+   | .hole mvar => if m mvar then [.hole mvar] else []
+ 
+ /-- Discard all nodes besides `.context` nodes and `TacticInfo` nodes. -/
+@@ -156,7 +156,7 @@ partial def findAllInfo (t : InfoTree) (ctx? : Option ContextInfo) (p : Info →
+   | context ctx t => t.findAllInfo (ctx.mergeIntoOuter? ctx?) p
+   | node i ts  =>
+     let info := if p i then [(i, ctx?)] else []
+-    let rest := ts.toList.flatMap (fun t => t.findAllInfo ctx? p)
++    let rest := ts.toList.bind (fun t => t.findAllInfo ctx? p)
+     info ++ rest
+   | _ => []
+ 
+@@ -214,13 +214,13 @@ def sorries (t : InfoTree) : List (ContextInfo × SorryType × Position × Posit
+ 
+ def tactics (t : InfoTree) : List (ContextInfo × Syntax × List MVarId × Position × Position × Array Name) :=
+     -- HACK: creating a child ngen
+-  t.findTacticNodes.map fun ⟨i, ctx⟩ => 
+-    let range := stxRange ctx.fileMap i.stx 
+-    ( { ctx with mctx := i.mctxBefore, ngen := ctx.ngen.mkChild.1 }, 
+-      i.stx, 
+-      i.goalsBefore, 
+-      range.fst, 
+-      range.snd, 
++  t.findTacticNodes.map fun ⟨i, ctx⟩ =>
++    let range := stxRange ctx.fileMap i.stx
++    ( { ctx with mctx := i.mctxBefore, ngen := ctx.ngen.mkChild.1 },
++      i.stx,
++      i.goalsBefore,
++      range.fst,
++      range.snd,
+       i.getUsedConstantsAsSet.toArray )
+ 
+ 
+diff --git a/REPL/Main.lean b/REPL/Main.lean
+index a4b97c3..8211b8c 100644
+--- a/REPL/Main.lean
++++ b/REPL/Main.lean
+@@ -95,7 +95,7 @@ def recordProofSnapshot (proofState : ProofSnapshot) : M m Nat := do
+   return id
+ 
+ def sorries (trees : List InfoTree) (env? : Option Environment) : M m (List Sorry) :=
+-  trees.flatMap InfoTree.sorries |>.filter (fun t => match t.2.1 with
++  trees.bind InfoTree.sorries |>.filter (fun t => match t.2.1 with
+     | .term _ none => false
+     | _ => true ) |>.mapM
+       fun ⟨ctx, g, pos, endPos⟩ => do
+@@ -117,7 +117,7 @@ def ppTactic (ctx : ContextInfo) (stx : Syntax) : IO Format :=
+     pure "<failed to pretty print>"
+ 
+ def tactics (trees : List InfoTree) : M m (List Tactic) :=
+-  trees.flatMap InfoTree.tactics |>.mapM
++  trees.bind InfoTree.tactics |>.mapM
+     fun ⟨ctx, stx, goals, pos, endPos, ns⟩ => do
+       let proofState := some (← ProofSnapshot.create ctx none none goals)
+       let goals := s!"{(← ctx.ppGoals goals)}".trim
+@@ -218,9 +218,9 @@ def runCommand (s : Command) : M IO (CommandResponse ⊕ Error) := do
+   let env ← recordCommandSnapshot cmdSnapshot
+   let jsonTrees := match s.infotree with
+   | some "full" => trees
+-  | some "tactics" => trees.flatMap InfoTree.retainTacticInfo
+-  | some "original" => trees.flatMap InfoTree.retainTacticInfo |>.flatMap InfoTree.retainOriginal
+-  | some "substantive" => trees.flatMap InfoTree.retainTacticInfo |>.flatMap InfoTree.retainSubstantive
++  | some "tactics" => trees.bind InfoTree.retainTacticInfo
++  | some "original" => trees.bind InfoTree.retainTacticInfo |>.bind InfoTree.retainOriginal
++  | some "substantive" => trees.bind InfoTree.retainTacticInfo |>.bind InfoTree.retainSubstantive
+   | _ => []
+   let infotree ← if jsonTrees.isEmpty then
+     pure none
+diff --git a/REPL/Snapshots.lean b/REPL/Snapshots.lean
+index 1114c24..7462141 100644
+--- a/REPL/Snapshots.lean
++++ b/REPL/Snapshots.lean
+@@ -83,7 +83,7 @@ def unpickle (path : FilePath) : IO (CommandSnapshot × CompactedRegion) := unsa
+   let ((imports, map₂, cmdState, cmdContext), region) ←
+     _root_.unpickle (Array Import × PHashMap Name ConstantInfo × CompactableCommandSnapshot ×
+       Command.Context) path
+-  let env ← (← importModules imports {} 0).replay (Std.HashMap.ofList map₂.toList)
++  let env ← (← importModules imports {} 0).replay (HashMap.ofList map₂.toList)
+   let p' : CommandSnapshot :=
+   { cmdState := { cmdState with env }
+     cmdContext }
+@@ -284,9 +284,9 @@ def unpickle (path : FilePath) (cmd? : Option CommandSnapshot) :
+   let env ← match cmd? with
+   | none =>
+     enableInitializersExecution
+-    (← importModules imports {} 0).replay (Std.HashMap.ofList map₂.toList)
++    (← importModules imports {} 0).replay (HashMap.ofList map₂.toList)
+   | some cmd =>
+-    cmd.cmdState.env.replay (Std.HashMap.ofList map₂.toList)
++    cmd.cmdState.env.replay (HashMap.ofList map₂.toList)
+   let p' : ProofSnapshot :=
+   { coreState := { coreState with env }
+     coreContext
+diff --git a/lean-toolchain b/lean-toolchain
+index 1e70935..29c0cea 100644
+--- a/lean-toolchain
++++ b/lean-toolchain
+@@ -1 +1 @@
+-leanprover/lean4:v4.14.0
++leanprover/lean4:v4.9.0-rc2
+diff --git a/test/Mathlib/lake-manifest.json b/test/Mathlib/lake-manifest.json
+index f312e5a..4d9fa90 100644
+--- a/test/Mathlib/lake-manifest.json
++++ b/test/Mathlib/lake-manifest.json
+@@ -1,95 +1,68 @@
+-{"version": "1.1.0",
++{"version": "1.0.0",
+  "packagesDir": ".lake/packages",
+  "packages":
+- [{"url": "https://github.com/leanprover-community/mathlib4",
++ [{"url": "https://github.com/leanprover-community/batteries",
+    "type": "git",
+    "subDir": null,
+-   "scope": "",
+-   "rev": "4bbdccd9c5f862bf90ff12f0a9e2c8be032b9a84",
+-   "name": "mathlib",
+-   "manifestFile": "lake-manifest.json",
+-   "inputRev": "v4.14.0",
+-   "inherited": false,
+-   "configFile": "lakefile.lean"},
+-  {"url": "https://github.com/leanprover-community/plausible",
+-   "type": "git",
+-   "subDir": null,
+-   "scope": "leanprover-community",
+-   "rev": "42dc02bdbc5d0c2f395718462a76c3d87318f7fa",
+-   "name": "plausible",
++   "rev": "15d42e1a92a80d0db5ca1c12123866ba392b9d76",
++   "name": "batteries",
+    "manifestFile": "lake-manifest.json",
+    "inputRev": "main",
+    "inherited": true,
+-   "configFile": "lakefile.toml"},
+-  {"url": "https://github.com/leanprover-community/LeanSearchClient",
++   "configFile": "lakefile.lean"},
++  {"url": "https://github.com/leanprover-community/quote4",
+    "type": "git",
+    "subDir": null,
+-   "scope": "leanprover-community",
+-   "rev": "d7caecce0d0f003fd5e9cce9a61f1dd6ba83142b",
+-   "name": "LeanSearchClient",
++   "rev": "a7bfa63f5dddbcab2d4e0569c4cac74b2585e2c6",
++   "name": "Qq",
+    "manifestFile": "lake-manifest.json",
+-   "inputRev": "main",
++   "inputRev": "master",
+    "inherited": true,
+-   "configFile": "lakefile.toml"},
+-  {"url": "https://github.com/leanprover-community/import-graph",
++   "configFile": "lakefile.lean"},
++  {"url": "https://github.com/leanprover-community/aesop",
+    "type": "git",
+    "subDir": null,
+-   "scope": "leanprover-community",
+-   "rev": "519e509a28864af5bed98033dd33b95cf08e9aa7",
+-   "name": "importGraph",
++   "rev": "3e1025b53ab7a8c8e6b82a72eccf2b109f09349e",
++   "name": "aesop",
+    "manifestFile": "lake-manifest.json",
+-   "inputRev": "v4.14.0",
++   "inputRev": "master",
+    "inherited": true,
+    "configFile": "lakefile.toml"},
+   {"url": "https://github.com/leanprover-community/ProofWidgets4",
+    "type": "git",
+    "subDir": null,
+-   "scope": "leanprover-community",
+-   "rev": "68280daef58803f68368eb2e53046dabcd270c9d",
++   "rev": "e6b6247c61280c77ade6bbf0bc3c66a44fe2e0c5",
+    "name": "proofwidgets",
+    "manifestFile": "lake-manifest.json",
+-   "inputRev": "v0.0.47",
++   "inputRev": "v0.0.36",
+    "inherited": true,
+    "configFile": "lakefile.lean"},
+-  {"url": "https://github.com/leanprover-community/aesop",
+-   "type": "git",
+-   "subDir": null,
+-   "scope": "leanprover-community",
+-   "rev": "5a0ec8588855265ade536f35bcdcf0fb24fd6030",
+-   "name": "aesop",
+-   "manifestFile": "lake-manifest.json",
+-   "inputRev": "v4.14.0",
+-   "inherited": true,
+-   "configFile": "lakefile.toml"},
+-  {"url": "https://github.com/leanprover-community/quote4",
++  {"url": "https://github.com/leanprover/lean4-cli",
+    "type": "git",
+    "subDir": null,
+-   "scope": "leanprover-community",
+-   "rev": "303b23fbcea94ac4f96e590c1cad6618fd4f5f41",
+-   "name": "Qq",
++   "rev": "a11566029bd9ec4f68a65394e8c3ff1af74c1a29",
++   "name": "Cli",
+    "manifestFile": "lake-manifest.json",
+-   "inputRev": "master",
++   "inputRev": "main",
+    "inherited": true,
+    "configFile": "lakefile.lean"},
+-  {"url": "https://github.com/leanprover-community/batteries",
++  {"url": "https://github.com/leanprover-community/import-graph.git",
+    "type": "git",
+    "subDir": null,
+-   "scope": "leanprover-community",
+-   "rev": "8d6c853f11a5172efa0e96b9f2be1a83d861cdd9",
+-   "name": "batteries",
++   "rev": "7983e959f8f4a79313215720de3ef1eca2d6d474",
++   "name": "importGraph",
+    "manifestFile": "lake-manifest.json",
+-   "inputRev": "v4.14.0",
++   "inputRev": "main",
+    "inherited": true,
+    "configFile": "lakefile.toml"},
+-  {"url": "https://github.com/leanprover/lean4-cli",
++  {"url": "https://github.com/leanprover-community/mathlib4",
+    "type": "git",
+    "subDir": null,
+-   "scope": "leanprover",
+-   "rev": "726b3c9ad13acca724d4651f14afc4804a7b0e4d",
+-   "name": "Cli",
++   "rev": "5ef3a830c97744118453efe44e7ddde3d4632385",
++   "name": "mathlib",
+    "manifestFile": "lake-manifest.json",
+-   "inputRev": "main",
+-   "inherited": true,
+-   "configFile": "lakefile.toml"}],
++   "inputRev": "v4.9.0-rc2",
++   "inherited": false,
++   "configFile": "lakefile.lean"}],
+  "name": "«repl-mathlib-tests»",
+  "lakeDir": ".lake"}
+diff --git a/test/Mathlib/lakefile.toml b/test/Mathlib/lakefile.toml
+index 6ff9631..bfbb06b 100644
+--- a/test/Mathlib/lakefile.toml
++++ b/test/Mathlib/lakefile.toml
+@@ -4,7 +4,7 @@ defaultTargets = ["ReplMathlibTests"]
+ [[require]]
+ name = "mathlib"
+ git = "https://github.com/leanprover-community/mathlib4"
+-rev = "v4.14.0"
++rev = "v4.9.0-rc2"
+ 
+ [[lean_lib]]
+ name = "ReplMathlibTests"
+diff --git a/test/Mathlib/lean-toolchain b/test/Mathlib/lean-toolchain
+index 401bc14..29c0cea 100644
+--- a/test/Mathlib/lean-toolchain
++++ b/test/Mathlib/lean-toolchain
+@@ -1 +1 @@
+-leanprover/lean4:v4.14.0
+\ No newline at end of file
++leanprover/lean4:v4.9.0-rc2
+diff --git a/test/all_tactics.expected.out b/test/all_tactics.expected.out
+index 6ec808c..5374db8 100644
+--- a/test/all_tactics.expected.out
++++ b/test/all_tactics.expected.out
+@@ -9,7 +9,7 @@
+    "tactic": "exact t",
+    "proofState": 1,
+    "pos": {"line": 1, "column": 32},
+-   "goals": "t : Nat\n⊢ Nat",
++   "goals": "t : Nat ⊢ Nat",
+    "endPos": {"line": 1, "column": 39}}],
+  "env": 0}
+ 
+diff --git a/test/calc.expected.out b/test/calc.expected.out
+index 94f6a9f..fde8fee 100644
+--- a/test/calc.expected.out
++++ b/test/calc.expected.out
+@@ -1,35 +1,22 @@
+ {"tactics":
+  [{"usedConstants":
+-   ["Trans.trans",
+-    "sorryAx",
+-    "instOfNatNat",
+-    "instTransEq",
+-    "Nat",
+-    "OfNat.ofNat",
+-    "Bool.false",
+-    "Eq"],
++   ["Trans.trans", "instOfNatNat", "instTransEq", "Nat", "OfNat.ofNat", "Eq"],
+    "tactic": "calc\n  3 = 4 := by sorry\n  4 = 5 := by sorry",
+    "proofState": 2,
+    "pos": {"line": 1, "column": 22},
+    "goals": "⊢ 3 = 5",
+    "endPos": {"line": 3, "column": 19}},
+-  {"usedConstants": [],
+-   "tactic": "\n  3 = 4 := by sorry\n  4 = 5 := by sorry",
+-   "proofState": 3,
+-   "pos": {"line": 2, "column": 2},
+-   "goals": "no goals",
+-   "endPos": {"line": 3, "column": 19}},
+   {"usedConstants":
+    ["sorryAx", "instOfNatNat", "Nat", "OfNat.ofNat", "Bool.false", "Eq"],
+    "tactic": "sorry",
+-   "proofState": 4,
++   "proofState": 3,
+    "pos": {"line": 2, "column": 14},
+    "goals": "⊢ 3 = 4",
+    "endPos": {"line": 2, "column": 19}},
+   {"usedConstants":
+    ["sorryAx", "instOfNatNat", "Nat", "OfNat.ofNat", "Bool.false", "Eq"],
+    "tactic": "sorry",
+-   "proofState": 5,
++   "proofState": 4,
+    "pos": {"line": 3, "column": 14},
+    "goals": "⊢ 4 = 5",
+    "endPos": {"line": 3, "column": 19}}],

--- a/versions/v4.9.0-rc3.diff
+++ b/versions/v4.9.0-rc3.diff
@@ -1,0 +1,379 @@
+diff --git a/REPL/Frontend.lean b/REPL/Frontend.lean
+index 9cc0914..a2bb150 100644
+--- a/REPL/Frontend.lean
++++ b/REPL/Frontend.lean
+@@ -20,7 +20,10 @@ def processCommandsWithInfoTrees
+     (commandState : Command.State) : IO (Command.State × List Message × List InfoTree) := do
+   let commandState := { commandState with infoState.enabled := true }
+   let s ← IO.processCommands inputCtx parserState commandState <&> Frontend.State.commandState
+-  pure (s, s.messages.toList, s.infoState.trees.toList)
++  let msgs := s.messages.toList.drop commandState.messages.toList.length
++  let trees := s.infoState.trees.toList.drop commandState.infoState.trees.size
++
++  pure (s, msgs, trees)
+ 
+ /--
+ Process some text input, with or without an existing command state.
+diff --git a/REPL/JSON.lean b/REPL/JSON.lean
+index d5c5ba2..b63c5ea 100644
+--- a/REPL/JSON.lean
++++ b/REPL/JSON.lean
+@@ -83,7 +83,7 @@ structure Sorry where
+ deriving FromJson
+ 
+ instance : ToJson Sorry where
+-  toJson r := Json.mkObj <| .flatten [
++  toJson r := Json.mkObj <| .join [
+     [("goal", r.goal)],
+     [("proofState", toJson r.proofState)],
+     if r.pos.line ≠ 0 then [("pos", toJson r.pos)] else [],
+@@ -132,7 +132,7 @@ def Json.nonemptyList [ToJson α] (k : String) : List α → List (String × Jso
+   | l  => [⟨k, toJson l⟩]
+ 
+ instance : ToJson CommandResponse where
+-  toJson r := Json.mkObj <| .flatten [
++  toJson r := Json.mkObj <| .join [
+     [("env", r.env)],
+     Json.nonemptyList "messages" r.messages,
+     Json.nonemptyList "sorries" r.sorries,
+@@ -153,7 +153,7 @@ structure ProofStepResponse where
+ deriving ToJson, FromJson
+ 
+ instance : ToJson ProofStepResponse where
+-  toJson r := Json.mkObj <| .flatten [
++  toJson r := Json.mkObj <| .join [
+     [("proofState", r.proofState)],
+     [("goals", toJson r.goals)],
+     Json.nonemptyList "messages" r.messages,
+diff --git a/REPL/Lean/Environment.lean b/REPL/Lean/Environment.lean
+index 0b4be3c..61d4e76 100644
+--- a/REPL/Lean/Environment.lean
++++ b/REPL/Lean/Environment.lean
+@@ -26,6 +26,6 @@ and then replace the new constants.
+ def unpickle (path : FilePath) : IO (Environment × CompactedRegion) := unsafe do
+   let ((imports, map₂), region) ← _root_.unpickle (Array Import × PHashMap Name ConstantInfo) path
+   let env ← importModules imports {} 0
+-  return (← env.replay (Std.HashMap.ofList map₂.toList), region)
++  return (← env.replay (HashMap.ofList map₂.toList), region)
+ 
+ end Lean.Environment
+diff --git a/REPL/Lean/InfoTree.lean b/REPL/Lean/InfoTree.lean
+index 7abf0b8..d3b28c1 100644
+--- a/REPL/Lean/InfoTree.lean
++++ b/REPL/Lean/InfoTree.lean
+@@ -131,9 +131,9 @@ partial def filter (p : Info → Bool) (m : MVarId → Bool := fun _ => false) :
+   | .context ctx tree => tree.filter p m |>.map (.context ctx)
+   | .node info children =>
+     if p info then
+-      [.node info (children.toList.map (filter p m)).flatten.toPArray']
++      [.node info (children.toList.map (filter p m)).join.toPArray']
+     else
+-      (children.toList.map (filter p m)).flatten
++      (children.toList.map (filter p m)).join
+   | .hole mvar => if m mvar then [.hole mvar] else []
+ 
+ /-- Discard all nodes besides `.context` nodes and `TacticInfo` nodes. -/
+@@ -156,7 +156,7 @@ partial def findAllInfo (t : InfoTree) (ctx? : Option ContextInfo) (p : Info →
+   | context ctx t => t.findAllInfo (ctx.mergeIntoOuter? ctx?) p
+   | node i ts  =>
+     let info := if p i then [(i, ctx?)] else []
+-    let rest := ts.toList.flatMap (fun t => t.findAllInfo ctx? p)
++    let rest := ts.toList.bind (fun t => t.findAllInfo ctx? p)
+     info ++ rest
+   | _ => []
+ 
+@@ -214,13 +214,13 @@ def sorries (t : InfoTree) : List (ContextInfo × SorryType × Position × Posit
+ 
+ def tactics (t : InfoTree) : List (ContextInfo × Syntax × List MVarId × Position × Position × Array Name) :=
+     -- HACK: creating a child ngen
+-  t.findTacticNodes.map fun ⟨i, ctx⟩ => 
+-    let range := stxRange ctx.fileMap i.stx 
+-    ( { ctx with mctx := i.mctxBefore, ngen := ctx.ngen.mkChild.1 }, 
+-      i.stx, 
+-      i.goalsBefore, 
+-      range.fst, 
+-      range.snd, 
++  t.findTacticNodes.map fun ⟨i, ctx⟩ =>
++    let range := stxRange ctx.fileMap i.stx
++    ( { ctx with mctx := i.mctxBefore, ngen := ctx.ngen.mkChild.1 },
++      i.stx,
++      i.goalsBefore,
++      range.fst,
++      range.snd,
+       i.getUsedConstantsAsSet.toArray )
+ 
+ 
+diff --git a/REPL/Main.lean b/REPL/Main.lean
+index a4b97c3..8211b8c 100644
+--- a/REPL/Main.lean
++++ b/REPL/Main.lean
+@@ -95,7 +95,7 @@ def recordProofSnapshot (proofState : ProofSnapshot) : M m Nat := do
+   return id
+ 
+ def sorries (trees : List InfoTree) (env? : Option Environment) : M m (List Sorry) :=
+-  trees.flatMap InfoTree.sorries |>.filter (fun t => match t.2.1 with
++  trees.bind InfoTree.sorries |>.filter (fun t => match t.2.1 with
+     | .term _ none => false
+     | _ => true ) |>.mapM
+       fun ⟨ctx, g, pos, endPos⟩ => do
+@@ -117,7 +117,7 @@ def ppTactic (ctx : ContextInfo) (stx : Syntax) : IO Format :=
+     pure "<failed to pretty print>"
+ 
+ def tactics (trees : List InfoTree) : M m (List Tactic) :=
+-  trees.flatMap InfoTree.tactics |>.mapM
++  trees.bind InfoTree.tactics |>.mapM
+     fun ⟨ctx, stx, goals, pos, endPos, ns⟩ => do
+       let proofState := some (← ProofSnapshot.create ctx none none goals)
+       let goals := s!"{(← ctx.ppGoals goals)}".trim
+@@ -218,9 +218,9 @@ def runCommand (s : Command) : M IO (CommandResponse ⊕ Error) := do
+   let env ← recordCommandSnapshot cmdSnapshot
+   let jsonTrees := match s.infotree with
+   | some "full" => trees
+-  | some "tactics" => trees.flatMap InfoTree.retainTacticInfo
+-  | some "original" => trees.flatMap InfoTree.retainTacticInfo |>.flatMap InfoTree.retainOriginal
+-  | some "substantive" => trees.flatMap InfoTree.retainTacticInfo |>.flatMap InfoTree.retainSubstantive
++  | some "tactics" => trees.bind InfoTree.retainTacticInfo
++  | some "original" => trees.bind InfoTree.retainTacticInfo |>.bind InfoTree.retainOriginal
++  | some "substantive" => trees.bind InfoTree.retainTacticInfo |>.bind InfoTree.retainSubstantive
+   | _ => []
+   let infotree ← if jsonTrees.isEmpty then
+     pure none
+diff --git a/REPL/Snapshots.lean b/REPL/Snapshots.lean
+index 1114c24..7462141 100644
+--- a/REPL/Snapshots.lean
++++ b/REPL/Snapshots.lean
+@@ -83,7 +83,7 @@ def unpickle (path : FilePath) : IO (CommandSnapshot × CompactedRegion) := unsa
+   let ((imports, map₂, cmdState, cmdContext), region) ←
+     _root_.unpickle (Array Import × PHashMap Name ConstantInfo × CompactableCommandSnapshot ×
+       Command.Context) path
+-  let env ← (← importModules imports {} 0).replay (Std.HashMap.ofList map₂.toList)
++  let env ← (← importModules imports {} 0).replay (HashMap.ofList map₂.toList)
+   let p' : CommandSnapshot :=
+   { cmdState := { cmdState with env }
+     cmdContext }
+@@ -284,9 +284,9 @@ def unpickle (path : FilePath) (cmd? : Option CommandSnapshot) :
+   let env ← match cmd? with
+   | none =>
+     enableInitializersExecution
+-    (← importModules imports {} 0).replay (Std.HashMap.ofList map₂.toList)
++    (← importModules imports {} 0).replay (HashMap.ofList map₂.toList)
+   | some cmd =>
+-    cmd.cmdState.env.replay (Std.HashMap.ofList map₂.toList)
++    cmd.cmdState.env.replay (HashMap.ofList map₂.toList)
+   let p' : ProofSnapshot :=
+   { coreState := { coreState with env }
+     coreContext
+diff --git a/lean-toolchain b/lean-toolchain
+index 1e70935..e5ea660 100644
+--- a/lean-toolchain
++++ b/lean-toolchain
+@@ -1 +1 @@
+-leanprover/lean4:v4.14.0
++leanprover/lean4:v4.9.0-rc3
+diff --git a/test/Mathlib/lake-manifest.json b/test/Mathlib/lake-manifest.json
+index f312e5a..db4177e 100644
+--- a/test/Mathlib/lake-manifest.json
++++ b/test/Mathlib/lake-manifest.json
+@@ -1,95 +1,68 @@
+-{"version": "1.1.0",
++{"version": "1.0.0",
+  "packagesDir": ".lake/packages",
+  "packages":
+- [{"url": "https://github.com/leanprover-community/mathlib4",
++ [{"url": "https://github.com/leanprover-community/batteries",
+    "type": "git",
+    "subDir": null,
+-   "scope": "",
+-   "rev": "4bbdccd9c5f862bf90ff12f0a9e2c8be032b9a84",
+-   "name": "mathlib",
+-   "manifestFile": "lake-manifest.json",
+-   "inputRev": "v4.14.0",
+-   "inherited": false,
+-   "configFile": "lakefile.lean"},
+-  {"url": "https://github.com/leanprover-community/plausible",
+-   "type": "git",
+-   "subDir": null,
+-   "scope": "leanprover-community",
+-   "rev": "42dc02bdbc5d0c2f395718462a76c3d87318f7fa",
+-   "name": "plausible",
++   "rev": "47e4cc5c5800c07d9bf232173c9941fa5bf68589",
++   "name": "batteries",
+    "manifestFile": "lake-manifest.json",
+    "inputRev": "main",
+    "inherited": true,
+-   "configFile": "lakefile.toml"},
+-  {"url": "https://github.com/leanprover-community/LeanSearchClient",
++   "configFile": "lakefile.lean"},
++  {"url": "https://github.com/leanprover-community/quote4",
+    "type": "git",
+    "subDir": null,
+-   "scope": "leanprover-community",
+-   "rev": "d7caecce0d0f003fd5e9cce9a61f1dd6ba83142b",
+-   "name": "LeanSearchClient",
++   "rev": "a7bfa63f5dddbcab2d4e0569c4cac74b2585e2c6",
++   "name": "Qq",
+    "manifestFile": "lake-manifest.json",
+-   "inputRev": "main",
++   "inputRev": "master",
+    "inherited": true,
+-   "configFile": "lakefile.toml"},
+-  {"url": "https://github.com/leanprover-community/import-graph",
++   "configFile": "lakefile.lean"},
++  {"url": "https://github.com/leanprover-community/aesop",
+    "type": "git",
+    "subDir": null,
+-   "scope": "leanprover-community",
+-   "rev": "519e509a28864af5bed98033dd33b95cf08e9aa7",
+-   "name": "importGraph",
++   "rev": "882561b77bd2aaa98bd8665a56821062bdb3034c",
++   "name": "aesop",
+    "manifestFile": "lake-manifest.json",
+-   "inputRev": "v4.14.0",
++   "inputRev": "master",
+    "inherited": true,
+    "configFile": "lakefile.toml"},
+   {"url": "https://github.com/leanprover-community/ProofWidgets4",
+    "type": "git",
+    "subDir": null,
+-   "scope": "leanprover-community",
+-   "rev": "68280daef58803f68368eb2e53046dabcd270c9d",
++   "rev": "e6b6247c61280c77ade6bbf0bc3c66a44fe2e0c5",
+    "name": "proofwidgets",
+    "manifestFile": "lake-manifest.json",
+-   "inputRev": "v0.0.47",
++   "inputRev": "v0.0.36",
+    "inherited": true,
+    "configFile": "lakefile.lean"},
+-  {"url": "https://github.com/leanprover-community/aesop",
+-   "type": "git",
+-   "subDir": null,
+-   "scope": "leanprover-community",
+-   "rev": "5a0ec8588855265ade536f35bcdcf0fb24fd6030",
+-   "name": "aesop",
+-   "manifestFile": "lake-manifest.json",
+-   "inputRev": "v4.14.0",
+-   "inherited": true,
+-   "configFile": "lakefile.toml"},
+-  {"url": "https://github.com/leanprover-community/quote4",
++  {"url": "https://github.com/leanprover/lean4-cli",
+    "type": "git",
+    "subDir": null,
+-   "scope": "leanprover-community",
+-   "rev": "303b23fbcea94ac4f96e590c1cad6618fd4f5f41",
+-   "name": "Qq",
++   "rev": "a11566029bd9ec4f68a65394e8c3ff1af74c1a29",
++   "name": "Cli",
+    "manifestFile": "lake-manifest.json",
+-   "inputRev": "master",
++   "inputRev": "main",
+    "inherited": true,
+    "configFile": "lakefile.lean"},
+-  {"url": "https://github.com/leanprover-community/batteries",
++  {"url": "https://github.com/leanprover-community/import-graph.git",
+    "type": "git",
+    "subDir": null,
+-   "scope": "leanprover-community",
+-   "rev": "8d6c853f11a5172efa0e96b9f2be1a83d861cdd9",
+-   "name": "batteries",
++   "rev": "1588be870b9c76fe62286e8f42f0b4dafa154c96",
++   "name": "importGraph",
+    "manifestFile": "lake-manifest.json",
+-   "inputRev": "v4.14.0",
++   "inputRev": "main",
+    "inherited": true,
+    "configFile": "lakefile.toml"},
+-  {"url": "https://github.com/leanprover/lean4-cli",
++  {"url": "https://github.com/leanprover-community/mathlib4",
+    "type": "git",
+    "subDir": null,
+-   "scope": "leanprover",
+-   "rev": "726b3c9ad13acca724d4651f14afc4804a7b0e4d",
+-   "name": "Cli",
++   "rev": "f9caf98dbed0eb3bb593396501ffebe61bda333b",
++   "name": "mathlib",
+    "manifestFile": "lake-manifest.json",
+-   "inputRev": "main",
+-   "inherited": true,
+-   "configFile": "lakefile.toml"}],
++   "inputRev": "v4.9.0-rc3",
++   "inherited": false,
++   "configFile": "lakefile.lean"}],
+  "name": "«repl-mathlib-tests»",
+  "lakeDir": ".lake"}
+diff --git a/test/Mathlib/lakefile.toml b/test/Mathlib/lakefile.toml
+index 6ff9631..967fee5 100644
+--- a/test/Mathlib/lakefile.toml
++++ b/test/Mathlib/lakefile.toml
+@@ -4,7 +4,7 @@ defaultTargets = ["ReplMathlibTests"]
+ [[require]]
+ name = "mathlib"
+ git = "https://github.com/leanprover-community/mathlib4"
+-rev = "v4.14.0"
++rev = "v4.9.0-rc3"
+ 
+ [[lean_lib]]
+ name = "ReplMathlibTests"
+diff --git a/test/Mathlib/lean-toolchain b/test/Mathlib/lean-toolchain
+index 401bc14..e5ea660 100644
+--- a/test/Mathlib/lean-toolchain
++++ b/test/Mathlib/lean-toolchain
+@@ -1 +1 @@
+-leanprover/lean4:v4.14.0
+\ No newline at end of file
++leanprover/lean4:v4.9.0-rc3
+diff --git a/test/all_tactics.expected.out b/test/all_tactics.expected.out
+index 6ec808c..5374db8 100644
+--- a/test/all_tactics.expected.out
++++ b/test/all_tactics.expected.out
+@@ -9,7 +9,7 @@
+    "tactic": "exact t",
+    "proofState": 1,
+    "pos": {"line": 1, "column": 32},
+-   "goals": "t : Nat\n⊢ Nat",
++   "goals": "t : Nat ⊢ Nat",
+    "endPos": {"line": 1, "column": 39}}],
+  "env": 0}
+ 
+diff --git a/test/calc.expected.out b/test/calc.expected.out
+index 94f6a9f..fde8fee 100644
+--- a/test/calc.expected.out
++++ b/test/calc.expected.out
+@@ -1,35 +1,22 @@
+ {"tactics":
+  [{"usedConstants":
+-   ["Trans.trans",
+-    "sorryAx",
+-    "instOfNatNat",
+-    "instTransEq",
+-    "Nat",
+-    "OfNat.ofNat",
+-    "Bool.false",
+-    "Eq"],
++   ["Trans.trans", "instOfNatNat", "instTransEq", "Nat", "OfNat.ofNat", "Eq"],
+    "tactic": "calc\n  3 = 4 := by sorry\n  4 = 5 := by sorry",
+    "proofState": 2,
+    "pos": {"line": 1, "column": 22},
+    "goals": "⊢ 3 = 5",
+    "endPos": {"line": 3, "column": 19}},
+-  {"usedConstants": [],
+-   "tactic": "\n  3 = 4 := by sorry\n  4 = 5 := by sorry",
+-   "proofState": 3,
+-   "pos": {"line": 2, "column": 2},
+-   "goals": "no goals",
+-   "endPos": {"line": 3, "column": 19}},
+   {"usedConstants":
+    ["sorryAx", "instOfNatNat", "Nat", "OfNat.ofNat", "Bool.false", "Eq"],
+    "tactic": "sorry",
+-   "proofState": 4,
++   "proofState": 3,
+    "pos": {"line": 2, "column": 14},
+    "goals": "⊢ 3 = 4",
+    "endPos": {"line": 2, "column": 19}},
+   {"usedConstants":
+    ["sorryAx", "instOfNatNat", "Nat", "OfNat.ofNat", "Bool.false", "Eq"],
+    "tactic": "sorry",
+-   "proofState": 5,
++   "proofState": 4,
+    "pos": {"line": 3, "column": 14},
+    "goals": "⊢ 4 = 5",
+    "endPos": {"line": 3, "column": 19}}],

--- a/versions/v4.9.0.diff
+++ b/versions/v4.9.0.diff
@@ -1,0 +1,386 @@
+diff --git a/REPL/Frontend.lean b/REPL/Frontend.lean
+index 9cc0914..a2bb150 100644
+--- a/REPL/Frontend.lean
++++ b/REPL/Frontend.lean
+@@ -20,7 +20,10 @@ def processCommandsWithInfoTrees
+     (commandState : Command.State) : IO (Command.State × List Message × List InfoTree) := do
+   let commandState := { commandState with infoState.enabled := true }
+   let s ← IO.processCommands inputCtx parserState commandState <&> Frontend.State.commandState
+-  pure (s, s.messages.toList, s.infoState.trees.toList)
++  let msgs := s.messages.toList.drop commandState.messages.toList.length
++  let trees := s.infoState.trees.toList.drop commandState.infoState.trees.size
++
++  pure (s, msgs, trees)
+ 
+ /--
+ Process some text input, with or without an existing command state.
+diff --git a/REPL/JSON.lean b/REPL/JSON.lean
+index d5c5ba2..b63c5ea 100644
+--- a/REPL/JSON.lean
++++ b/REPL/JSON.lean
+@@ -83,7 +83,7 @@ structure Sorry where
+ deriving FromJson
+ 
+ instance : ToJson Sorry where
+-  toJson r := Json.mkObj <| .flatten [
++  toJson r := Json.mkObj <| .join [
+     [("goal", r.goal)],
+     [("proofState", toJson r.proofState)],
+     if r.pos.line ≠ 0 then [("pos", toJson r.pos)] else [],
+@@ -132,7 +132,7 @@ def Json.nonemptyList [ToJson α] (k : String) : List α → List (String × Jso
+   | l  => [⟨k, toJson l⟩]
+ 
+ instance : ToJson CommandResponse where
+-  toJson r := Json.mkObj <| .flatten [
++  toJson r := Json.mkObj <| .join [
+     [("env", r.env)],
+     Json.nonemptyList "messages" r.messages,
+     Json.nonemptyList "sorries" r.sorries,
+@@ -153,7 +153,7 @@ structure ProofStepResponse where
+ deriving ToJson, FromJson
+ 
+ instance : ToJson ProofStepResponse where
+-  toJson r := Json.mkObj <| .flatten [
++  toJson r := Json.mkObj <| .join [
+     [("proofState", r.proofState)],
+     [("goals", toJson r.goals)],
+     Json.nonemptyList "messages" r.messages,
+diff --git a/REPL/Lean/Environment.lean b/REPL/Lean/Environment.lean
+index 0b4be3c..61d4e76 100644
+--- a/REPL/Lean/Environment.lean
++++ b/REPL/Lean/Environment.lean
+@@ -26,6 +26,6 @@ and then replace the new constants.
+ def unpickle (path : FilePath) : IO (Environment × CompactedRegion) := unsafe do
+   let ((imports, map₂), region) ← _root_.unpickle (Array Import × PHashMap Name ConstantInfo) path
+   let env ← importModules imports {} 0
+-  return (← env.replay (Std.HashMap.ofList map₂.toList), region)
++  return (← env.replay (HashMap.ofList map₂.toList), region)
+ 
+ end Lean.Environment
+diff --git a/REPL/Lean/InfoTree.lean b/REPL/Lean/InfoTree.lean
+index 7abf0b8..d3b28c1 100644
+--- a/REPL/Lean/InfoTree.lean
++++ b/REPL/Lean/InfoTree.lean
+@@ -131,9 +131,9 @@ partial def filter (p : Info → Bool) (m : MVarId → Bool := fun _ => false) :
+   | .context ctx tree => tree.filter p m |>.map (.context ctx)
+   | .node info children =>
+     if p info then
+-      [.node info (children.toList.map (filter p m)).flatten.toPArray']
++      [.node info (children.toList.map (filter p m)).join.toPArray']
+     else
+-      (children.toList.map (filter p m)).flatten
++      (children.toList.map (filter p m)).join
+   | .hole mvar => if m mvar then [.hole mvar] else []
+ 
+ /-- Discard all nodes besides `.context` nodes and `TacticInfo` nodes. -/
+@@ -156,7 +156,7 @@ partial def findAllInfo (t : InfoTree) (ctx? : Option ContextInfo) (p : Info →
+   | context ctx t => t.findAllInfo (ctx.mergeIntoOuter? ctx?) p
+   | node i ts  =>
+     let info := if p i then [(i, ctx?)] else []
+-    let rest := ts.toList.flatMap (fun t => t.findAllInfo ctx? p)
++    let rest := ts.toList.bind (fun t => t.findAllInfo ctx? p)
+     info ++ rest
+   | _ => []
+ 
+@@ -214,13 +214,13 @@ def sorries (t : InfoTree) : List (ContextInfo × SorryType × Position × Posit
+ 
+ def tactics (t : InfoTree) : List (ContextInfo × Syntax × List MVarId × Position × Position × Array Name) :=
+     -- HACK: creating a child ngen
+-  t.findTacticNodes.map fun ⟨i, ctx⟩ => 
+-    let range := stxRange ctx.fileMap i.stx 
+-    ( { ctx with mctx := i.mctxBefore, ngen := ctx.ngen.mkChild.1 }, 
+-      i.stx, 
+-      i.goalsBefore, 
+-      range.fst, 
+-      range.snd, 
++  t.findTacticNodes.map fun ⟨i, ctx⟩ =>
++    let range := stxRange ctx.fileMap i.stx
++    ( { ctx with mctx := i.mctxBefore, ngen := ctx.ngen.mkChild.1 },
++      i.stx,
++      i.goalsBefore,
++      range.fst,
++      range.snd,
+       i.getUsedConstantsAsSet.toArray )
+ 
+ 
+diff --git a/REPL/Main.lean b/REPL/Main.lean
+index a4b97c3..8211b8c 100644
+--- a/REPL/Main.lean
++++ b/REPL/Main.lean
+@@ -95,7 +95,7 @@ def recordProofSnapshot (proofState : ProofSnapshot) : M m Nat := do
+   return id
+ 
+ def sorries (trees : List InfoTree) (env? : Option Environment) : M m (List Sorry) :=
+-  trees.flatMap InfoTree.sorries |>.filter (fun t => match t.2.1 with
++  trees.bind InfoTree.sorries |>.filter (fun t => match t.2.1 with
+     | .term _ none => false
+     | _ => true ) |>.mapM
+       fun ⟨ctx, g, pos, endPos⟩ => do
+@@ -117,7 +117,7 @@ def ppTactic (ctx : ContextInfo) (stx : Syntax) : IO Format :=
+     pure "<failed to pretty print>"
+ 
+ def tactics (trees : List InfoTree) : M m (List Tactic) :=
+-  trees.flatMap InfoTree.tactics |>.mapM
++  trees.bind InfoTree.tactics |>.mapM
+     fun ⟨ctx, stx, goals, pos, endPos, ns⟩ => do
+       let proofState := some (← ProofSnapshot.create ctx none none goals)
+       let goals := s!"{(← ctx.ppGoals goals)}".trim
+@@ -218,9 +218,9 @@ def runCommand (s : Command) : M IO (CommandResponse ⊕ Error) := do
+   let env ← recordCommandSnapshot cmdSnapshot
+   let jsonTrees := match s.infotree with
+   | some "full" => trees
+-  | some "tactics" => trees.flatMap InfoTree.retainTacticInfo
+-  | some "original" => trees.flatMap InfoTree.retainTacticInfo |>.flatMap InfoTree.retainOriginal
+-  | some "substantive" => trees.flatMap InfoTree.retainTacticInfo |>.flatMap InfoTree.retainSubstantive
++  | some "tactics" => trees.bind InfoTree.retainTacticInfo
++  | some "original" => trees.bind InfoTree.retainTacticInfo |>.bind InfoTree.retainOriginal
++  | some "substantive" => trees.bind InfoTree.retainTacticInfo |>.bind InfoTree.retainSubstantive
+   | _ => []
+   let infotree ← if jsonTrees.isEmpty then
+     pure none
+diff --git a/REPL/Snapshots.lean b/REPL/Snapshots.lean
+index 1114c24..7462141 100644
+--- a/REPL/Snapshots.lean
++++ b/REPL/Snapshots.lean
+@@ -83,7 +83,7 @@ def unpickle (path : FilePath) : IO (CommandSnapshot × CompactedRegion) := unsa
+   let ((imports, map₂, cmdState, cmdContext), region) ←
+     _root_.unpickle (Array Import × PHashMap Name ConstantInfo × CompactableCommandSnapshot ×
+       Command.Context) path
+-  let env ← (← importModules imports {} 0).replay (Std.HashMap.ofList map₂.toList)
++  let env ← (← importModules imports {} 0).replay (HashMap.ofList map₂.toList)
+   let p' : CommandSnapshot :=
+   { cmdState := { cmdState with env }
+     cmdContext }
+@@ -284,9 +284,9 @@ def unpickle (path : FilePath) (cmd? : Option CommandSnapshot) :
+   let env ← match cmd? with
+   | none =>
+     enableInitializersExecution
+-    (← importModules imports {} 0).replay (Std.HashMap.ofList map₂.toList)
++    (← importModules imports {} 0).replay (HashMap.ofList map₂.toList)
+   | some cmd =>
+-    cmd.cmdState.env.replay (Std.HashMap.ofList map₂.toList)
++    cmd.cmdState.env.replay (HashMap.ofList map₂.toList)
+   let p' : ProofSnapshot :=
+   { coreState := { coreState with env }
+     coreContext
+diff --git a/lean-toolchain b/lean-toolchain
+index 1e70935..4ef27c4 100644
+--- a/lean-toolchain
++++ b/lean-toolchain
+@@ -1 +1 @@
+-leanprover/lean4:v4.14.0
++leanprover/lean4:v4.9.0
+diff --git a/test/Mathlib/lake-manifest.json b/test/Mathlib/lake-manifest.json
+index f312e5a..c4cdada 100644
+--- a/test/Mathlib/lake-manifest.json
++++ b/test/Mathlib/lake-manifest.json
+@@ -1,95 +1,68 @@
+-{"version": "1.1.0",
++{"version": "1.0.0",
+  "packagesDir": ".lake/packages",
+  "packages":
+- [{"url": "https://github.com/leanprover-community/mathlib4",
++ [{"url": "https://github.com/leanprover-community/batteries",
+    "type": "git",
+    "subDir": null,
+-   "scope": "",
+-   "rev": "4bbdccd9c5f862bf90ff12f0a9e2c8be032b9a84",
+-   "name": "mathlib",
+-   "manifestFile": "lake-manifest.json",
+-   "inputRev": "v4.14.0",
+-   "inherited": false,
+-   "configFile": "lakefile.lean"},
+-  {"url": "https://github.com/leanprover-community/plausible",
+-   "type": "git",
+-   "subDir": null,
+-   "scope": "leanprover-community",
+-   "rev": "42dc02bdbc5d0c2f395718462a76c3d87318f7fa",
+-   "name": "plausible",
++   "rev": "54bb04c3119f24fde14b9068c4b2e69db52a1450",
++   "name": "batteries",
+    "manifestFile": "lake-manifest.json",
+    "inputRev": "main",
+    "inherited": true,
+-   "configFile": "lakefile.toml"},
+-  {"url": "https://github.com/leanprover-community/LeanSearchClient",
++   "configFile": "lakefile.lean"},
++  {"url": "https://github.com/leanprover-community/quote4",
+    "type": "git",
+    "subDir": null,
+-   "scope": "leanprover-community",
+-   "rev": "d7caecce0d0f003fd5e9cce9a61f1dd6ba83142b",
+-   "name": "LeanSearchClient",
++   "rev": "a7bfa63f5dddbcab2d4e0569c4cac74b2585e2c6",
++   "name": "Qq",
+    "manifestFile": "lake-manifest.json",
+-   "inputRev": "main",
++   "inputRev": "master",
+    "inherited": true,
+-   "configFile": "lakefile.toml"},
+-  {"url": "https://github.com/leanprover-community/import-graph",
++   "configFile": "lakefile.lean"},
++  {"url": "https://github.com/leanprover-community/aesop",
+    "type": "git",
+    "subDir": null,
+-   "scope": "leanprover-community",
+-   "rev": "519e509a28864af5bed98033dd33b95cf08e9aa7",
+-   "name": "importGraph",
++   "rev": "06cca4bd36b2af743d4858c5cc31604aa9da26bc",
++   "name": "aesop",
+    "manifestFile": "lake-manifest.json",
+-   "inputRev": "v4.14.0",
++   "inputRev": "master",
+    "inherited": true,
+    "configFile": "lakefile.toml"},
+   {"url": "https://github.com/leanprover-community/ProofWidgets4",
+    "type": "git",
+    "subDir": null,
+-   "scope": "leanprover-community",
+-   "rev": "68280daef58803f68368eb2e53046dabcd270c9d",
++   "rev": "87c1e7a427d8e21b6eaf8401f12897f52e2c3be9",
+    "name": "proofwidgets",
+    "manifestFile": "lake-manifest.json",
+-   "inputRev": "v0.0.47",
++   "inputRev": "v0.0.38",
+    "inherited": true,
+    "configFile": "lakefile.lean"},
+-  {"url": "https://github.com/leanprover-community/aesop",
+-   "type": "git",
+-   "subDir": null,
+-   "scope": "leanprover-community",
+-   "rev": "5a0ec8588855265ade536f35bcdcf0fb24fd6030",
+-   "name": "aesop",
+-   "manifestFile": "lake-manifest.json",
+-   "inputRev": "v4.14.0",
+-   "inherited": true,
+-   "configFile": "lakefile.toml"},
+-  {"url": "https://github.com/leanprover-community/quote4",
++  {"url": "https://github.com/leanprover/lean4-cli",
+    "type": "git",
+    "subDir": null,
+-   "scope": "leanprover-community",
+-   "rev": "303b23fbcea94ac4f96e590c1cad6618fd4f5f41",
+-   "name": "Qq",
++   "rev": "a11566029bd9ec4f68a65394e8c3ff1af74c1a29",
++   "name": "Cli",
+    "manifestFile": "lake-manifest.json",
+-   "inputRev": "master",
++   "inputRev": "main",
+    "inherited": true,
+    "configFile": "lakefile.lean"},
+-  {"url": "https://github.com/leanprover-community/batteries",
++  {"url": "https://github.com/leanprover-community/import-graph.git",
+    "type": "git",
+    "subDir": null,
+-   "scope": "leanprover-community",
+-   "rev": "8d6c853f11a5172efa0e96b9f2be1a83d861cdd9",
+-   "name": "batteries",
++   "rev": "c29c3cdce415240e9dcec5c583ad5d36f83f9c71",
++   "name": "importGraph",
+    "manifestFile": "lake-manifest.json",
+-   "inputRev": "v4.14.0",
++   "inputRev": "main",
+    "inherited": true,
+    "configFile": "lakefile.toml"},
+-  {"url": "https://github.com/leanprover/lean4-cli",
++  {"url": "https://github.com/leanprover-community/mathlib4",
+    "type": "git",
+    "subDir": null,
+-   "scope": "leanprover",
+-   "rev": "726b3c9ad13acca724d4651f14afc4804a7b0e4d",
+-   "name": "Cli",
++   "rev": "f0957a7575317490107578ebaee9efaf8e62a4ab",
++   "name": "mathlib",
+    "manifestFile": "lake-manifest.json",
+-   "inputRev": "main",
+-   "inherited": true,
+-   "configFile": "lakefile.toml"}],
++   "inputRev": "master",
++   "inherited": false,
++   "configFile": "lakefile.lean"}],
+  "name": "«repl-mathlib-tests»",
+  "lakeDir": ".lake"}
+diff --git a/test/Mathlib/lakefile.toml b/test/Mathlib/lakefile.toml
+index 6ff9631..af41e27 100644
+--- a/test/Mathlib/lakefile.toml
++++ b/test/Mathlib/lakefile.toml
+@@ -1,11 +1,11 @@
+-name = "«repl-mathlib-tests»"
++name           = "«repl-mathlib-tests»"
+ defaultTargets = ["ReplMathlibTests"]
+ 
+ [[require]]
+ name = "mathlib"
+-git = "https://github.com/leanprover-community/mathlib4"
+-rev = "v4.14.0"
++git  = "https://github.com/leanprover-community/mathlib4"
++rev  = "master"
+ 
+ [[lean_lib]]
+-name = "ReplMathlibTests"
++name  = "ReplMathlibTests"
+ globs = ["test.+"]
+diff --git a/test/Mathlib/lean-toolchain b/test/Mathlib/lean-toolchain
+index 401bc14..4ef27c4 100644
+--- a/test/Mathlib/lean-toolchain
++++ b/test/Mathlib/lean-toolchain
+@@ -1 +1 @@
+-leanprover/lean4:v4.14.0
+\ No newline at end of file
++leanprover/lean4:v4.9.0
+diff --git a/test/all_tactics.expected.out b/test/all_tactics.expected.out
+index 6ec808c..5374db8 100644
+--- a/test/all_tactics.expected.out
++++ b/test/all_tactics.expected.out
+@@ -9,7 +9,7 @@
+    "tactic": "exact t",
+    "proofState": 1,
+    "pos": {"line": 1, "column": 32},
+-   "goals": "t : Nat\n⊢ Nat",
++   "goals": "t : Nat ⊢ Nat",
+    "endPos": {"line": 1, "column": 39}}],
+  "env": 0}
+ 
+diff --git a/test/calc.expected.out b/test/calc.expected.out
+index 94f6a9f..fde8fee 100644
+--- a/test/calc.expected.out
++++ b/test/calc.expected.out
+@@ -1,35 +1,22 @@
+ {"tactics":
+  [{"usedConstants":
+-   ["Trans.trans",
+-    "sorryAx",
+-    "instOfNatNat",
+-    "instTransEq",
+-    "Nat",
+-    "OfNat.ofNat",
+-    "Bool.false",
+-    "Eq"],
++   ["Trans.trans", "instOfNatNat", "instTransEq", "Nat", "OfNat.ofNat", "Eq"],
+    "tactic": "calc\n  3 = 4 := by sorry\n  4 = 5 := by sorry",
+    "proofState": 2,
+    "pos": {"line": 1, "column": 22},
+    "goals": "⊢ 3 = 5",
+    "endPos": {"line": 3, "column": 19}},
+-  {"usedConstants": [],
+-   "tactic": "\n  3 = 4 := by sorry\n  4 = 5 := by sorry",
+-   "proofState": 3,
+-   "pos": {"line": 2, "column": 2},
+-   "goals": "no goals",
+-   "endPos": {"line": 3, "column": 19}},
+   {"usedConstants":
+    ["sorryAx", "instOfNatNat", "Nat", "OfNat.ofNat", "Bool.false", "Eq"],
+    "tactic": "sorry",
+-   "proofState": 4,
++   "proofState": 3,
+    "pos": {"line": 2, "column": 14},
+    "goals": "⊢ 3 = 4",
+    "endPos": {"line": 2, "column": 19}},
+   {"usedConstants":
+    ["sorryAx", "instOfNatNat", "Nat", "OfNat.ofNat", "Bool.false", "Eq"],
+    "tactic": "sorry",
+-   "proofState": 5,
++   "proofState": 4,
+    "pos": {"line": 3, "column": 14},
+    "goals": "⊢ 4 = 5",
+    "endPos": {"line": 3, "column": 19}}],

--- a/versions/v4.9.1.diff
+++ b/versions/v4.9.1.diff
@@ -1,0 +1,380 @@
+diff --git a/REPL/Frontend.lean b/REPL/Frontend.lean
+index 9cc0914..a2bb150 100644
+--- a/REPL/Frontend.lean
++++ b/REPL/Frontend.lean
+@@ -20,7 +20,10 @@ def processCommandsWithInfoTrees
+     (commandState : Command.State) : IO (Command.State × List Message × List InfoTree) := do
+   let commandState := { commandState with infoState.enabled := true }
+   let s ← IO.processCommands inputCtx parserState commandState <&> Frontend.State.commandState
+-  pure (s, s.messages.toList, s.infoState.trees.toList)
++  let msgs := s.messages.toList.drop commandState.messages.toList.length
++  let trees := s.infoState.trees.toList.drop commandState.infoState.trees.size
++
++  pure (s, msgs, trees)
+ 
+ /--
+ Process some text input, with or without an existing command state.
+diff --git a/REPL/JSON.lean b/REPL/JSON.lean
+index d5c5ba2..b63c5ea 100644
+--- a/REPL/JSON.lean
++++ b/REPL/JSON.lean
+@@ -83,7 +83,7 @@ structure Sorry where
+ deriving FromJson
+ 
+ instance : ToJson Sorry where
+-  toJson r := Json.mkObj <| .flatten [
++  toJson r := Json.mkObj <| .join [
+     [("goal", r.goal)],
+     [("proofState", toJson r.proofState)],
+     if r.pos.line ≠ 0 then [("pos", toJson r.pos)] else [],
+@@ -132,7 +132,7 @@ def Json.nonemptyList [ToJson α] (k : String) : List α → List (String × Jso
+   | l  => [⟨k, toJson l⟩]
+ 
+ instance : ToJson CommandResponse where
+-  toJson r := Json.mkObj <| .flatten [
++  toJson r := Json.mkObj <| .join [
+     [("env", r.env)],
+     Json.nonemptyList "messages" r.messages,
+     Json.nonemptyList "sorries" r.sorries,
+@@ -153,7 +153,7 @@ structure ProofStepResponse where
+ deriving ToJson, FromJson
+ 
+ instance : ToJson ProofStepResponse where
+-  toJson r := Json.mkObj <| .flatten [
++  toJson r := Json.mkObj <| .join [
+     [("proofState", r.proofState)],
+     [("goals", toJson r.goals)],
+     Json.nonemptyList "messages" r.messages,
+diff --git a/REPL/Lean/Environment.lean b/REPL/Lean/Environment.lean
+index 0b4be3c..61d4e76 100644
+--- a/REPL/Lean/Environment.lean
++++ b/REPL/Lean/Environment.lean
+@@ -26,6 +26,6 @@ and then replace the new constants.
+ def unpickle (path : FilePath) : IO (Environment × CompactedRegion) := unsafe do
+   let ((imports, map₂), region) ← _root_.unpickle (Array Import × PHashMap Name ConstantInfo) path
+   let env ← importModules imports {} 0
+-  return (← env.replay (Std.HashMap.ofList map₂.toList), region)
++  return (← env.replay (HashMap.ofList map₂.toList), region)
+ 
+ end Lean.Environment
+diff --git a/REPL/Lean/InfoTree.lean b/REPL/Lean/InfoTree.lean
+index 7abf0b8..d3b28c1 100644
+--- a/REPL/Lean/InfoTree.lean
++++ b/REPL/Lean/InfoTree.lean
+@@ -131,9 +131,9 @@ partial def filter (p : Info → Bool) (m : MVarId → Bool := fun _ => false) :
+   | .context ctx tree => tree.filter p m |>.map (.context ctx)
+   | .node info children =>
+     if p info then
+-      [.node info (children.toList.map (filter p m)).flatten.toPArray']
++      [.node info (children.toList.map (filter p m)).join.toPArray']
+     else
+-      (children.toList.map (filter p m)).flatten
++      (children.toList.map (filter p m)).join
+   | .hole mvar => if m mvar then [.hole mvar] else []
+ 
+ /-- Discard all nodes besides `.context` nodes and `TacticInfo` nodes. -/
+@@ -156,7 +156,7 @@ partial def findAllInfo (t : InfoTree) (ctx? : Option ContextInfo) (p : Info →
+   | context ctx t => t.findAllInfo (ctx.mergeIntoOuter? ctx?) p
+   | node i ts  =>
+     let info := if p i then [(i, ctx?)] else []
+-    let rest := ts.toList.flatMap (fun t => t.findAllInfo ctx? p)
++    let rest := ts.toList.bind (fun t => t.findAllInfo ctx? p)
+     info ++ rest
+   | _ => []
+ 
+@@ -214,13 +214,13 @@ def sorries (t : InfoTree) : List (ContextInfo × SorryType × Position × Posit
+ 
+ def tactics (t : InfoTree) : List (ContextInfo × Syntax × List MVarId × Position × Position × Array Name) :=
+     -- HACK: creating a child ngen
+-  t.findTacticNodes.map fun ⟨i, ctx⟩ => 
+-    let range := stxRange ctx.fileMap i.stx 
+-    ( { ctx with mctx := i.mctxBefore, ngen := ctx.ngen.mkChild.1 }, 
+-      i.stx, 
+-      i.goalsBefore, 
+-      range.fst, 
+-      range.snd, 
++  t.findTacticNodes.map fun ⟨i, ctx⟩ =>
++    let range := stxRange ctx.fileMap i.stx
++    ( { ctx with mctx := i.mctxBefore, ngen := ctx.ngen.mkChild.1 },
++      i.stx,
++      i.goalsBefore,
++      range.fst,
++      range.snd,
+       i.getUsedConstantsAsSet.toArray )
+ 
+ 
+diff --git a/REPL/Main.lean b/REPL/Main.lean
+index a4b97c3..8211b8c 100644
+--- a/REPL/Main.lean
++++ b/REPL/Main.lean
+@@ -95,7 +95,7 @@ def recordProofSnapshot (proofState : ProofSnapshot) : M m Nat := do
+   return id
+ 
+ def sorries (trees : List InfoTree) (env? : Option Environment) : M m (List Sorry) :=
+-  trees.flatMap InfoTree.sorries |>.filter (fun t => match t.2.1 with
++  trees.bind InfoTree.sorries |>.filter (fun t => match t.2.1 with
+     | .term _ none => false
+     | _ => true ) |>.mapM
+       fun ⟨ctx, g, pos, endPos⟩ => do
+@@ -117,7 +117,7 @@ def ppTactic (ctx : ContextInfo) (stx : Syntax) : IO Format :=
+     pure "<failed to pretty print>"
+ 
+ def tactics (trees : List InfoTree) : M m (List Tactic) :=
+-  trees.flatMap InfoTree.tactics |>.mapM
++  trees.bind InfoTree.tactics |>.mapM
+     fun ⟨ctx, stx, goals, pos, endPos, ns⟩ => do
+       let proofState := some (← ProofSnapshot.create ctx none none goals)
+       let goals := s!"{(← ctx.ppGoals goals)}".trim
+@@ -218,9 +218,9 @@ def runCommand (s : Command) : M IO (CommandResponse ⊕ Error) := do
+   let env ← recordCommandSnapshot cmdSnapshot
+   let jsonTrees := match s.infotree with
+   | some "full" => trees
+-  | some "tactics" => trees.flatMap InfoTree.retainTacticInfo
+-  | some "original" => trees.flatMap InfoTree.retainTacticInfo |>.flatMap InfoTree.retainOriginal
+-  | some "substantive" => trees.flatMap InfoTree.retainTacticInfo |>.flatMap InfoTree.retainSubstantive
++  | some "tactics" => trees.bind InfoTree.retainTacticInfo
++  | some "original" => trees.bind InfoTree.retainTacticInfo |>.bind InfoTree.retainOriginal
++  | some "substantive" => trees.bind InfoTree.retainTacticInfo |>.bind InfoTree.retainSubstantive
+   | _ => []
+   let infotree ← if jsonTrees.isEmpty then
+     pure none
+diff --git a/REPL/Snapshots.lean b/REPL/Snapshots.lean
+index 1114c24..7462141 100644
+--- a/REPL/Snapshots.lean
++++ b/REPL/Snapshots.lean
+@@ -83,7 +83,7 @@ def unpickle (path : FilePath) : IO (CommandSnapshot × CompactedRegion) := unsa
+   let ((imports, map₂, cmdState, cmdContext), region) ←
+     _root_.unpickle (Array Import × PHashMap Name ConstantInfo × CompactableCommandSnapshot ×
+       Command.Context) path
+-  let env ← (← importModules imports {} 0).replay (Std.HashMap.ofList map₂.toList)
++  let env ← (← importModules imports {} 0).replay (HashMap.ofList map₂.toList)
+   let p' : CommandSnapshot :=
+   { cmdState := { cmdState with env }
+     cmdContext }
+@@ -284,9 +284,9 @@ def unpickle (path : FilePath) (cmd? : Option CommandSnapshot) :
+   let env ← match cmd? with
+   | none =>
+     enableInitializersExecution
+-    (← importModules imports {} 0).replay (Std.HashMap.ofList map₂.toList)
++    (← importModules imports {} 0).replay (HashMap.ofList map₂.toList)
+   | some cmd =>
+-    cmd.cmdState.env.replay (Std.HashMap.ofList map₂.toList)
++    cmd.cmdState.env.replay (HashMap.ofList map₂.toList)
+   let p' : ProofSnapshot :=
+   { coreState := { coreState with env }
+     coreContext
+diff --git a/lean-toolchain b/lean-toolchain
+index 1e70935..acd5c69 100644
+--- a/lean-toolchain
++++ b/lean-toolchain
+@@ -1 +1 @@
+-leanprover/lean4:v4.14.0
++leanprover/lean4:v4.9.1
+diff --git a/test/Mathlib/lake-manifest.json b/test/Mathlib/lake-manifest.json
+index f312e5a..dc5a124 100644
+--- a/test/Mathlib/lake-manifest.json
++++ b/test/Mathlib/lake-manifest.json
+@@ -1,95 +1,68 @@
+-{"version": "1.1.0",
++{"version": "1.0.0",
+  "packagesDir": ".lake/packages",
+  "packages":
+- [{"url": "https://github.com/leanprover-community/mathlib4",
++ [{"url": "https://github.com/leanprover-community/batteries",
+    "type": "git",
+    "subDir": null,
+-   "scope": "",
+-   "rev": "4bbdccd9c5f862bf90ff12f0a9e2c8be032b9a84",
+-   "name": "mathlib",
+-   "manifestFile": "lake-manifest.json",
+-   "inputRev": "v4.14.0",
+-   "inherited": false,
+-   "configFile": "lakefile.lean"},
+-  {"url": "https://github.com/leanprover-community/plausible",
+-   "type": "git",
+-   "subDir": null,
+-   "scope": "leanprover-community",
+-   "rev": "42dc02bdbc5d0c2f395718462a76c3d87318f7fa",
+-   "name": "plausible",
++   "rev": "dcea9ce8aba248927fb2ea8d5752bfe1e3fe7b44",
++   "name": "batteries",
+    "manifestFile": "lake-manifest.json",
+-   "inputRev": "main",
++   "inputRev": "v4.9.1",
+    "inherited": true,
+-   "configFile": "lakefile.toml"},
+-  {"url": "https://github.com/leanprover-community/LeanSearchClient",
++   "configFile": "lakefile.lean"},
++  {"url": "https://github.com/leanprover-community/quote4",
+    "type": "git",
+    "subDir": null,
+-   "scope": "leanprover-community",
+-   "rev": "d7caecce0d0f003fd5e9cce9a61f1dd6ba83142b",
+-   "name": "LeanSearchClient",
++   "rev": "a7bfa63f5dddbcab2d4e0569c4cac74b2585e2c6",
++   "name": "Qq",
+    "manifestFile": "lake-manifest.json",
+-   "inputRev": "main",
++   "inputRev": "master",
+    "inherited": true,
+-   "configFile": "lakefile.toml"},
+-  {"url": "https://github.com/leanprover-community/import-graph",
++   "configFile": "lakefile.lean"},
++  {"url": "https://github.com/leanprover-community/aesop",
+    "type": "git",
+    "subDir": null,
+-   "scope": "leanprover-community",
+-   "rev": "519e509a28864af5bed98033dd33b95cf08e9aa7",
+-   "name": "importGraph",
++   "rev": "06cca4bd36b2af743d4858c5cc31604aa9da26bc",
++   "name": "aesop",
+    "manifestFile": "lake-manifest.json",
+-   "inputRev": "v4.14.0",
++   "inputRev": "master",
+    "inherited": true,
+    "configFile": "lakefile.toml"},
+   {"url": "https://github.com/leanprover-community/ProofWidgets4",
+    "type": "git",
+    "subDir": null,
+-   "scope": "leanprover-community",
+-   "rev": "68280daef58803f68368eb2e53046dabcd270c9d",
++   "rev": "87c1e7a427d8e21b6eaf8401f12897f52e2c3be9",
+    "name": "proofwidgets",
+    "manifestFile": "lake-manifest.json",
+-   "inputRev": "v0.0.47",
++   "inputRev": "v0.0.38",
+    "inherited": true,
+    "configFile": "lakefile.lean"},
+-  {"url": "https://github.com/leanprover-community/aesop",
+-   "type": "git",
+-   "subDir": null,
+-   "scope": "leanprover-community",
+-   "rev": "5a0ec8588855265ade536f35bcdcf0fb24fd6030",
+-   "name": "aesop",
+-   "manifestFile": "lake-manifest.json",
+-   "inputRev": "v4.14.0",
+-   "inherited": true,
+-   "configFile": "lakefile.toml"},
+-  {"url": "https://github.com/leanprover-community/quote4",
++  {"url": "https://github.com/leanprover/lean4-cli",
+    "type": "git",
+    "subDir": null,
+-   "scope": "leanprover-community",
+-   "rev": "303b23fbcea94ac4f96e590c1cad6618fd4f5f41",
+-   "name": "Qq",
++   "rev": "a11566029bd9ec4f68a65394e8c3ff1af74c1a29",
++   "name": "Cli",
+    "manifestFile": "lake-manifest.json",
+-   "inputRev": "master",
++   "inputRev": "main",
+    "inherited": true,
+    "configFile": "lakefile.lean"},
+-  {"url": "https://github.com/leanprover-community/batteries",
++  {"url": "https://github.com/leanprover-community/import-graph.git",
+    "type": "git",
+    "subDir": null,
+-   "scope": "leanprover-community",
+-   "rev": "8d6c853f11a5172efa0e96b9f2be1a83d861cdd9",
+-   "name": "batteries",
++   "rev": "c29c3cdce415240e9dcec5c583ad5d36f83f9c71",
++   "name": "importGraph",
+    "manifestFile": "lake-manifest.json",
+-   "inputRev": "v4.14.0",
++   "inputRev": "main",
+    "inherited": true,
+    "configFile": "lakefile.toml"},
+-  {"url": "https://github.com/leanprover/lean4-cli",
++  {"url": "https://github.com/leanprover-community/mathlib4",
+    "type": "git",
+    "subDir": null,
+-   "scope": "leanprover",
+-   "rev": "726b3c9ad13acca724d4651f14afc4804a7b0e4d",
+-   "name": "Cli",
++   "rev": "09d33efc68d3ad52db77b731d7253675395a14aa",
++   "name": "mathlib",
+    "manifestFile": "lake-manifest.json",
+-   "inputRev": "main",
+-   "inherited": true,
+-   "configFile": "lakefile.toml"}],
++   "inputRev": "v4.9.1",
++   "inherited": false,
++   "configFile": "lakefile.lean"}],
+  "name": "«repl-mathlib-tests»",
+  "lakeDir": ".lake"}
+diff --git a/test/Mathlib/lakefile.toml b/test/Mathlib/lakefile.toml
+index 6ff9631..f25faeb 100644
+--- a/test/Mathlib/lakefile.toml
++++ b/test/Mathlib/lakefile.toml
+@@ -4,7 +4,7 @@ defaultTargets = ["ReplMathlibTests"]
+ [[require]]
+ name = "mathlib"
+ git = "https://github.com/leanprover-community/mathlib4"
+-rev = "v4.14.0"
++rev = "v4.9.1"
+ 
+ [[lean_lib]]
+ name = "ReplMathlibTests"
+diff --git a/test/Mathlib/lean-toolchain b/test/Mathlib/lean-toolchain
+index 401bc14..acd5c69 100644
+--- a/test/Mathlib/lean-toolchain
++++ b/test/Mathlib/lean-toolchain
+@@ -1 +1 @@
+-leanprover/lean4:v4.14.0
+\ No newline at end of file
++leanprover/lean4:v4.9.1
+diff --git a/test/all_tactics.expected.out b/test/all_tactics.expected.out
+index 6ec808c..5374db8 100644
+--- a/test/all_tactics.expected.out
++++ b/test/all_tactics.expected.out
+@@ -9,7 +9,7 @@
+    "tactic": "exact t",
+    "proofState": 1,
+    "pos": {"line": 1, "column": 32},
+-   "goals": "t : Nat\n⊢ Nat",
++   "goals": "t : Nat ⊢ Nat",
+    "endPos": {"line": 1, "column": 39}}],
+  "env": 0}
+ 
+diff --git a/test/calc.expected.out b/test/calc.expected.out
+index 94f6a9f..fde8fee 100644
+--- a/test/calc.expected.out
++++ b/test/calc.expected.out
+@@ -1,35 +1,22 @@
+ {"tactics":
+  [{"usedConstants":
+-   ["Trans.trans",
+-    "sorryAx",
+-    "instOfNatNat",
+-    "instTransEq",
+-    "Nat",
+-    "OfNat.ofNat",
+-    "Bool.false",
+-    "Eq"],
++   ["Trans.trans", "instOfNatNat", "instTransEq", "Nat", "OfNat.ofNat", "Eq"],
+    "tactic": "calc\n  3 = 4 := by sorry\n  4 = 5 := by sorry",
+    "proofState": 2,
+    "pos": {"line": 1, "column": 22},
+    "goals": "⊢ 3 = 5",
+    "endPos": {"line": 3, "column": 19}},
+-  {"usedConstants": [],
+-   "tactic": "\n  3 = 4 := by sorry\n  4 = 5 := by sorry",
+-   "proofState": 3,
+-   "pos": {"line": 2, "column": 2},
+-   "goals": "no goals",
+-   "endPos": {"line": 3, "column": 19}},
+   {"usedConstants":
+    ["sorryAx", "instOfNatNat", "Nat", "OfNat.ofNat", "Bool.false", "Eq"],
+    "tactic": "sorry",
+-   "proofState": 4,
++   "proofState": 3,
+    "pos": {"line": 2, "column": 14},
+    "goals": "⊢ 3 = 4",
+    "endPos": {"line": 2, "column": 19}},
+   {"usedConstants":
+    ["sorryAx", "instOfNatNat", "Nat", "OfNat.ofNat", "Bool.false", "Eq"],
+    "tactic": "sorry",
+-   "proofState": 5,
++   "proofState": 4,
+    "pos": {"line": 3, "column": 14},
+    "goals": "⊢ 4 = 5",
+    "endPos": {"line": 3, "column": 19}}],


### PR DESCRIPTION
When new features and bug fixes are added to the REPL, they are not backported to previous Lean versions using the official tag-based approach. Here we choose to decouple Lean versions from the REPL versions by adding a `versions` folder containing diff files to apply when switching to a different Lean version.
The CI is updated accordingly.